### PR TITLE
FIX/no_helptext_due_to_uncaught_exception

### DIFF
--- a/cli/scaleout/cli/main.py
+++ b/cli/scaleout/cli/main.py
@@ -28,7 +28,11 @@ def main(ctx, project_dir):
 
     if ctx.invoked_subcommand not in ('init',):
         # TODO add support for cwd change, config-file specification
+        from scaleout.errors import InvalidConfigurationError
         from scaleout.project import Project
         from scaleout.runtime.runtime import Runtime
-        from scaleout.studioclient import StudioClient
-        ctx.obj['CLIENT'] = StudioClient()
+        try:
+            from scaleout.studioclient import StudioClient
+            ctx.obj['CLIENT'] = StudioClient()
+        except InvalidConfigurationError:
+            pass

--- a/cli/scaleout/project.py
+++ b/cli/scaleout/project.py
@@ -22,7 +22,7 @@ class Project:
         try:
             self._load_config()
         except Exception:
-            raise InvalidConfigurationError("Missing configuration file").
+            raise InvalidConfigurationError("Missing configuration file")
 
         try:
             self.api_endpoint = os.path.join(self.config['so_domain_name'], '/api')

--- a/cli/scaleout/project.py
+++ b/cli/scaleout/project.py
@@ -19,7 +19,11 @@ class Project:
         else:
             self.config_file_path = config_file_path
 
-        self._load_config()
+        try:
+            self._load_config()
+        except Exception:
+            raise InvalidConfigurationError("Missing configuration file").
+
         try:
             self.api_endpoint = os.path.join(self.config['so_domain_name'], '/api')
             self.auth_url = self.config["auth_url"]


### PR DESCRIPTION
FIXED: Currently when running the CLI client the helptext wont show for subcommands due to an uncaught configurationerror exception.
FIXED: Furthermore the configurationerrror is not properly thrown on load configurration error or missing configfile.

