### PR TITLE
Fix/bucket bad strcmp

### DIFF
--- a/cli/scaleout/cli/main.py
+++ b/cli/scaleout/cli/main.py
@@ -28,7 +28,11 @@ def main(ctx, project_dir):
 
     if ctx.invoked_subcommand not in ('init',):
         # TODO add support for cwd change, config-file specification
+        from scaleout.errors import InvalidConfigurationError
         from scaleout.project import Project
         from scaleout.runtime.runtime import Runtime
-        from scaleout.studioclient import StudioClient
-        ctx.obj['CLIENT'] = StudioClient()
+        try:
+            from scaleout.studioclient import StudioClient
+            ctx.obj['CLIENT'] = StudioClient()
+        except InvalidConfigurationError:
+            pass

--- a/cli/scaleout/project.py
+++ b/cli/scaleout/project.py
@@ -19,7 +19,11 @@ class Project:
         else:
             self.config_file_path = config_file_path
 
-        self._load_config()
+        try:
+            self._load_config()
+        except Exception:
+            raise InvalidConfigurationError("Missing configuration file").
+
         try:
             self.api_endpoint = os.path.join(self.config['so_domain_name'], '/api')
             self.auth_url = self.config["auth_url"]

--- a/cli/scaleout/repository/miniorepository.py
+++ b/cli/scaleout/repository/miniorepository.py
@@ -46,7 +46,7 @@ class MINIORepository(Repository):
                 secure=self.secure_mode)
 
         self.create_bucket(self.bucket)
-    
+
     def create_bucket(self, bucket_name):
         try:
             response = self.client.make_bucket(bucket_name)
@@ -59,7 +59,7 @@ class MINIORepository(Repository):
 
     def set_artifact(self, instance_name, instance, is_file=False, bucket=''):
         """ Instance must be a byte-like object. """
-        if bucket is '':
+        if not bucket:
             bucket = self.bucket
         if is_file==True:
             self.client.fput_object(bucket, instance_name, instance)
@@ -68,7 +68,7 @@ class MINIORepository(Repository):
                 self.client.put_object(bucket, instance_name, io.BytesIO(instance), len(instance))
             except Exception as e:
                 raise Exception("Could not load data into bytes {}".format(e))
-        
+
         return True
 
     def get_artifact(self, instance_name):
@@ -78,7 +78,7 @@ class MINIORepository(Repository):
             return data.read()
         except Exception as e:
             raise Exception("Could not fetch data from bucket, {}".format(e))
-        
+
 
     def list_artifacts(self):
         try:


### PR DESCRIPTION
Current compare is throwing a warning. 
Replace with python proper stringcompare with empty string.