### PR TITLE
Feature/stackn 103

### DIFF
--- a/cli/scaleout/auth.py
+++ b/cli/scaleout/auth.py
@@ -1,10 +1,115 @@
 
+import os
 import requests
 from scaleout.errors import AuthenticationError
 import json
+import jwt
+import base64
+from getpass import getpass
 
-def login(url,username,password):
-	""" Login to Studio services. """
+
+def keycloak_user_auth(username, password, host_url, client_id='studio-api', realm='STACKn'):
+    discovery_url = '{}/auth/realms/{}'.format(host_url, realm)
+    res = requests.get(discovery_url)
+    if res:
+        realm_info = res.json()
+        public_key = realm_info['public_key']
+    else:
+        print('Failed to discover realm settings: '+realm)
+        return None
+    
+    token_url = '{}/auth/realms/{}/protocol/openid-connect/token'.format(host_url, realm)
+    req = {'client_id': client_id,
+           'grant_type': 'password',
+           'username': username,
+           'password': password}
+    res = requests.post(token_url, data=req)
+    if res:
+        res = res.json()
+    else:
+        print('Failed to authenticate.')
+        print(res.text)
+    if 'access_token' in res:
+        return res['access_token'], res['refresh_token'], public_key
+    else:
+        print('User: '+username+' denied access to client: '+client_id)
+        return False
+
+
+def write_tokens(deployment, token, refresh_token, public_key, host_url):
+    dirpath = os.path.expanduser('~/.scaleout/'+deployment)
+    if not os.path.exists(dirpath):
+        os.mkdir(dirpath)
+    token_file = open(dirpath+'/token', 'w')
+    refresh_token_file = open(dirpath+'/refresh_token', 'w')
+    public_key_file = open(dirpath+'/public_key', 'w')
+    active_host = open(os.path.expanduser('~/.scaleout/active'), 'w')
+    file_host_url = open(os.path.expanduser(dirpath+'/host'), 'w')
+    token_file.write(token)
+    token_file.close()
+    refresh_token_file.write(refresh_token)
+    refresh_token_file.close()
+    active_host.write(deployment)
+    file_host_url.write(host_url)
+    active_host.close()
+    public_key_file.write(public_key)
+    public_key_file.close()
+    file_host_url.close()
+
+def verify_or_refresh_jwt_token(deployment, access_token, refresh_token, public_key, host_url, client_id='studio-api', realm='STACKn'):
+    try:
+        public_key_full = '-----BEGIN PUBLIC KEY-----\n'+public_key+'\n-----END PUBLIC KEY-----'
+        access_token_json = jwt.decode(access_token, public_key_full, algorithms='RS256', audience='account')
+        # print('Token valid for user '+access_token_json['preferred_username'])
+    except:
+        # Try to refresh token
+        print('Refreshing token...')
+        token_url = '{}/auth/realms/{}/protocol/openid-connect/token'.format(host_url, realm)
+        req = {'grant_type': 'refresh_token',
+               'client_id': client_id,
+               'refresh_token': refresh_token}
+        res = requests.post(token_url, data=req)
+        resp = res.json()
+        if 'access_token' in resp:
+            access_token = resp['access_token']
+            refresh_token = resp['refresh_token']
+            write_tokens(deployment, access_token, refresh_token, public_key, host_url)
+            # return res['access_token'], res['refresh_token'], public_key
+        else:
+            print('Failed to authenticate with token, please login again.')
+            print(res.text)
+            access_token = login()
+
+
+    return access_token
+
+
+
+def login():
+    """ Login to Studio services. """
+    deployment = input('Name: ')
+    host = input('Host: ')
+    username = input('Username: ')
+    password = getpass()
+    access_token, refresh_token, public_key = keycloak_user_auth(username, password, host)
+    # dirname = base64.urlsafe_b64encode(host.encode("utf-8")).decode("utf-8")
+    dirpath = os.path.expanduser('~/.scaleout/'+deployment)
+    if not os.path.exists(dirpath):
+        os.mkdir(dirpath)
+    write_tokens(deployment, access_token, refresh_token, public_key, host)
+    return access_token
+    # token_file = open(dirpath+'/token', 'w')
+    # refresh_token_file = open(dirpath+'/refresh_token', 'w')
+    # public_key_file = open(dirpath+'/public_key', 'w')
+    # active_host = open(os.path.expanduser('~/.scaleout/active'), 'w')
+    # token_file.write(token)
+    # token_file.close()
+    # refresh_token_file.write(refresh_token)
+    # refresh_token_file.close()
+    # active_host.write(deployment)
+    # active_host.close()
+    # public_key_file.write(public_key)
+    # public_key_file.close()
 
 def get_bearer_token(url, username, password):
     """ Exchange username,password for an auth token.

--- a/cli/scaleout/auth.py
+++ b/cli/scaleout/auth.py
@@ -6,6 +6,7 @@ import json
 import jwt
 import base64
 from getpass import getpass
+from scaleout.utils.file import dump_to_file, load_from_file
 
 
 def keycloak_user_auth(username, password, host_url, client_id='studio-api', realm='STACKn'):
@@ -35,45 +36,71 @@ def keycloak_user_auth(username, password, host_url, client_id='studio-api', rea
         print('User: '+username+' denied access to client: '+client_id)
         return False
 
+def write_stackn_config(updated_values):
+    dirpath = os.path.expanduser('~/.scaleout/')
+    if os.path.exists(dirpath+'stackn.json'):
+        stackn_config, load_status = load_from_file('stackn', dirpath)
+        if not load_status:
+            print('Failed to load stackn config (~/.scaleout/stackn.json)')
+            return False
+    else:
+        stackn_config = dict()
+
+    for key, value in updated_values.items():
+        stackn_config[key] = value
+    
+    dump_to_file(stackn_config, 'stackn', dirpath)
+
+    
 
 def write_tokens(deployment, token, refresh_token, public_key, host_url):
     dirpath = os.path.expanduser('~/.scaleout/'+deployment)
     if not os.path.exists(dirpath):
         os.mkdir(dirpath)
-    token_file = open(dirpath+'/token', 'w')
-    refresh_token_file = open(dirpath+'/refresh_token', 'w')
-    public_key_file = open(dirpath+'/public_key', 'w')
-    active_host = open(os.path.expanduser('~/.scaleout/active'), 'w')
-    file_host_url = open(os.path.expanduser(dirpath+'/host'), 'w')
-    token_file.write(token)
-    token_file.close()
-    refresh_token_file.write(refresh_token)
-    refresh_token_file.close()
-    active_host.write(deployment)
-    file_host_url.write(host_url)
-    active_host.close()
-    public_key_file.write(public_key)
-    public_key_file.close()
-    file_host_url.close()
+    dep_config = {'access_token': token,
+                  'refresh_token': refresh_token,
+                  'public_key': public_key,
+                  'host_url': host_url}
+    dump_to_file(dep_config, 'user', dirpath)
 
-def verify_or_refresh_jwt_token(deployment, access_token, refresh_token, public_key, host_url, client_id='studio-api', realm='STACKn'):
+def get_token(client_id='studio-api', realm='STACKn'):
+    stackn_config, load_status = load_from_file('stackn', os.path.expanduser('~/.scaleout/'))
+    if not load_status:
+        print('Failed to load stackn config file.')
+        return None
+
+    active_dir = os.path.expanduser('~/.scaleout/')+stackn_config['active']
+    token_config, load_status = load_from_file('user', active_dir)
+    if not load_status:
+        print('Failed to load user config file.')
+        return None
+    
+    access_token = token_config['access_token']
+
     try:
-        public_key_full = '-----BEGIN PUBLIC KEY-----\n'+public_key+'\n-----END PUBLIC KEY-----'
-        access_token_json = jwt.decode(access_token, public_key_full, algorithms='RS256', audience='account')
+        public_key_full = '-----BEGIN PUBLIC KEY-----\n'+token_config['public_key']+'\n-----END PUBLIC KEY-----'
+        access_token_json = jwt.decode(access_token,
+                                       public_key_full,
+                                       algorithms='RS256',
+                                       audience='account')
         # print('Token valid for user '+access_token_json['preferred_username'])
     except:
         # Try to refresh token
         print('Refreshing token...')
-        token_url = '{}/auth/realms/{}/protocol/openid-connect/token'.format(host_url, realm)
+        token_url = '{}/auth/realms/{}/protocol/openid-connect/token'.format(token_config['host_url'], realm)
         req = {'grant_type': 'refresh_token',
                'client_id': client_id,
-               'refresh_token': refresh_token}
+               'refresh_token': token_config['refresh_token']}
         res = requests.post(token_url, data=req)
         resp = res.json()
         if 'access_token' in resp:
             access_token = resp['access_token']
             refresh_token = resp['refresh_token']
-            write_tokens(deployment, access_token, refresh_token, public_key, host_url)
+            write_tokens(stackn_config['active'],
+                         access_token,
+                         refresh_token,
+                         token_config['public_key'],
+                         token_config['host_url'])
             # return res['access_token'], res['refresh_token'], public_key
         else:
             print('Failed to authenticate with token, please login again.')
@@ -97,6 +124,7 @@ def login():
     if not os.path.exists(dirpath):
         os.mkdir(dirpath)
     write_tokens(deployment, access_token, refresh_token, public_key, host)
+    write_stackn_config({'active': deployment})
     return access_token
     # token_file = open(dirpath+'/token', 'w')
     # refresh_token_file = open(dirpath+'/refresh_token', 'w')

--- a/cli/scaleout/cli/__init__.py
+++ b/cli/scaleout/cli/__init__.py
@@ -4,3 +4,4 @@ from .model_cmd import model_cmd
 from .create_cmd import create_cmd
 from .get_cmd import get_cmd
 from .delete_cmd import delete_cmd
+from .login_cmd import login_cmd

--- a/cli/scaleout/cli/__init__.py
+++ b/cli/scaleout/cli/__init__.py
@@ -4,4 +4,5 @@ from .model_cmd import model_cmd
 from .create_cmd import create_cmd
 from .get_cmd import get_cmd
 from .delete_cmd import delete_cmd
-from .login_cmd import login_cmd
+from .login_cmd import setup_cmd, status_cmd
+from .set_cmd import set_cmd

--- a/cli/scaleout/cli/login_cmd.py
+++ b/cli/scaleout/cli/login_cmd.py
@@ -1,0 +1,23 @@
+import click
+from .main import main
+import requests
+from scaleout.auth import login 
+from .helpers import create_table
+
+@click.option('--daemon',
+              is_flag=True,
+              help=(
+                      "Specify to run in daemon mode."
+              )
+              )
+
+@main.group('login')
+@click.pass_context
+def login_cmd(ctx, daemon):
+    pass
+
+@login_cmd.command('login')
+@click.pass_context
+def login_cmd(ctx):
+    login()
+

--- a/cli/scaleout/cli/login_cmd.py
+++ b/cli/scaleout/cli/login_cmd.py
@@ -1,18 +1,41 @@
 import click
 from .main import main
 import requests
-from scaleout.auth import login 
+from scaleout.auth import login, get_stackn_config, get_remote_config
 from .helpers import create_table
 
-@click.option('--daemon',
-              is_flag=True,
-              help=(
-                      "Specify to run in daemon mode."
-              )
-              )
+# @click.option('--daemon',
+#               is_flag=True,
+#               help=(
+#                       "Specify to run in daemon mode."
+#               )
+#               )
+
+@main.command('setup')
+@click.pass_context
+def setup_cmd(ctx):
+    login()
 
 @main.command('login')
 @click.pass_context
-def login_cmd(ctx, daemon):
-    login()
+def login_cmd(ctx):
+    stackn_config, load_status = get_stackn_config()
+    if not load_status:
+        print('Failed to load STACKn config.')
+        return
 
+    remote_config, load_status = get_remote_config()
+    if remote_config:
+        login(deployment=stackn_config['active'],
+              keycloak_host=remote_config['keycloak_url'],
+              studio_host=remote_config['studio_url'])
+
+@main.command('status')
+@click.pass_context
+def status_cmd(ctx):
+    stackn_config, load_status = get_stackn_config()
+    if not load_status:
+        print('Failed to load STACKn config.')
+    else:
+        print('Context: '+stackn_config['active'])
+        print('Project: '+stackn_config['active_project'])

--- a/cli/scaleout/cli/login_cmd.py
+++ b/cli/scaleout/cli/login_cmd.py
@@ -11,13 +11,8 @@ from .helpers import create_table
               )
               )
 
-@main.group('login')
+@main.command('login')
 @click.pass_context
 def login_cmd(ctx, daemon):
-    pass
-
-@login_cmd.command('login')
-@click.pass_context
-def login_cmd(ctx):
     login()
 

--- a/cli/scaleout/cli/main.py
+++ b/cli/scaleout/cli/main.py
@@ -26,7 +26,7 @@ def main(ctx, project_dir):
     ctx.obj = dict()
     ctx.obj['PROJECT_DIR'] = project_dir
 
-    if ctx.invoked_subcommand not in ('init',):
+    if ctx.invoked_subcommand not in ('init','login',):
         # TODO add support for cwd change, config-file specification
         from scaleout.project import Project
         from scaleout.runtime.runtime import Runtime

--- a/cli/scaleout/cli/main.py
+++ b/cli/scaleout/cli/main.py
@@ -26,7 +26,7 @@ def main(ctx, project_dir):
     ctx.obj = dict()
     ctx.obj['PROJECT_DIR'] = project_dir
 
-    if ctx.invoked_subcommand not in ('init','login',):
+    if ctx.invoked_subcommand not in ('init','login','status'):
         # TODO add support for cwd change, config-file specification
         from scaleout.project import Project
         from scaleout.runtime.runtime import Runtime

--- a/cli/scaleout/cli/set_cmd.py
+++ b/cli/scaleout/cli/set_cmd.py
@@ -1,0 +1,25 @@
+import click
+from .main import main
+import requests
+from scaleout.auth import login 
+from .helpers import create_table
+import os
+
+@click.option('--daemon',
+              is_flag=True,
+              help=(
+                      "Specify to run in daemon mode."
+              )
+              )
+
+@main.group('set')
+@click.pass_context
+def set_cmd(ctx, daemon):
+    pass
+
+@set_cmd.command('remote')
+@click.pass_context
+def remote_cmd(ctx):
+    remote = input('Remote: ')
+    # os.
+

--- a/cli/scaleout/cli/set_cmd.py
+++ b/cli/scaleout/cli/set_cmd.py
@@ -1,7 +1,8 @@
 import click
 from .main import main
 import requests
-from scaleout.auth import login 
+from scaleout.studioclient import StudioClient
+import scaleout.auth as sauth
 from .helpers import create_table
 import os
 
@@ -18,8 +19,30 @@ def set_cmd(ctx, daemon):
     pass
 
 @set_cmd.command('remote')
+@click.option('-r', '--remote', required=False)
 @click.pass_context
-def remote_cmd(ctx):
-    remote = input('Remote: ')
-    # os.
+def remote_cmd(ctx, remote):
+    if not remote:
+        remote = input('Remote: ')
+    stackn_config, load_status = sauth.get_stackn_config()
+    if not load_status:
+        print('Failed to load STACKn config.')
+    else:
+        dirpath = os.path.expanduser('~/.scaleout/'+remote)
+        if not os.path.exists(dirpath):
+            print("Remote doesn't exist.")
+            print("Configure remote with 'stackn setup'")
+        else:
+            stackn_config['active'] = remote
+            sauth.write_stackn_config(stackn_config)
+            print('New context: '+remote)
 
+@set_cmd.command('project')
+@click.option('-p', '--project', required=False)
+@click.pass_context
+def project_cmd(ctx, project):
+    if not project:
+        project = input('Project: ')
+
+    client = ctx.obj['CLIENT']
+    client.set_project(project)

--- a/cli/scaleout/repository/miniorepository.py
+++ b/cli/scaleout/repository/miniorepository.py
@@ -42,16 +42,13 @@ class MINIORepository(Repository):
                                 secret_key=secret_key,
                                 secure=self.secure_mode, http_client=manager)
         else:
-            print('creating client')
-            print("{}".format(config['minio_host']))
-            print(self.secure_mode)
             self.client = Minio("{}".format(config['minio_host']),
                                 access_key=access_key,
                                 secret_key=secret_key,
                                 secure=self.secure_mode)
-        print('creating bucket')
+
         self.create_bucket(self.bucket)
-        print('done')
+
 
     def create_bucket(self, bucket_name):
         try:

--- a/cli/scaleout/repository/miniorepository.py
+++ b/cli/scaleout/repository/miniorepository.py
@@ -42,11 +42,16 @@ class MINIORepository(Repository):
                                 secret_key=secret_key,
                                 secure=self.secure_mode, http_client=manager)
         else:
+            print('creating client')
+            print("{}".format(config['minio_host']))
+            print(self.secure_mode)
             self.client = Minio("{}".format(config['minio_host']),
                                 access_key=access_key,
                                 secret_key=secret_key,
                                 secure=self.secure_mode)
+        print('creating bucket')
         self.create_bucket(self.bucket)
+        print('done')
 
     def create_bucket(self, bucket_name):
         try:

--- a/cli/scaleout/runtime/runtime.py
+++ b/cli/scaleout/runtime/runtime.py
@@ -8,4 +8,3 @@ class Runtime(Project):
         # The config file is read by the Project constructor
         super(Runtime, self).__init__(cwd, config_file)
 
-        self.client = self.config['access_key']

--- a/cli/scaleout/studioclient.py
+++ b/cli/scaleout/studioclient.py
@@ -3,6 +3,7 @@ from scaleout.config.config import load_config as load_conf, get_default_config_
 
 from scaleout.runtime.runtime import Runtime
 
+import scaleout.auth as sauth
 from scaleout.auth import get_bearer_token
 from scaleout.errors import AuthenticationError
 
@@ -38,7 +39,35 @@ class StudioClient(Runtime):
         self.global_domain = self.config['so_domain_name']
         # TODO: This assumes a certain url-schema
         self.api_url = self.auth_url.replace("/api-token-auth",'')
-        self.auth_headers = {'Authorization': 'Token {}'.format(self.config['token'])}
+
+        # 1. Verify token locally
+        # 2. If expired, refresh against client studio-api
+        # (Need to add client studio-api to default config)
+        # (Need to add token-exchange option to default values.yaml)
+        file_active = open(os.path.expanduser('~/.scaleout/active'), 'r')
+        active_remote = file_active.read()
+        file_active.close()
+        active_dir = os.path.expanduser('~/.scaleout/'+active_remote)
+        file_token = open(active_dir+'/token', 'r')
+        file_refresh_token = open(active_dir+'/refresh_token', 'r')
+        file_public_key = open(active_dir+'/public_key', 'r')
+        file_host_url = open(active_dir+'/host', 'r')
+        access_token = file_token.read()
+        refresh_token = file_refresh_token.read()
+        public_key = file_public_key.read()
+        host_url = file_host_url.read()
+        file_token.close()
+        file_refresh_token.close()
+        file_public_key.close()
+        file_host_url.close()
+
+        token = sauth.verify_or_refresh_jwt_token(active_remote,
+                                                 access_token,
+                                                 refresh_token,
+                                                 public_key,
+                                                 host_url)
+
+        self.auth_headers = {'Authorization': 'Token {}'.format(token)}
 
         # Fetch and set all active API endpoints
         self.get_endpoints()

--- a/cli/scaleout/studioclient.py
+++ b/cli/scaleout/studioclient.py
@@ -6,6 +6,7 @@ from scaleout.runtime.runtime import Runtime
 import scaleout.auth as sauth
 from scaleout.auth import get_bearer_token
 from scaleout.errors import AuthenticationError
+from scaleout.utils.file import dump_to_file, load_from_file
 
 import requests
 import json
@@ -40,32 +41,7 @@ class StudioClient(Runtime):
         # TODO: This assumes a certain url-schema
         self.api_url = self.auth_url.replace("/api-token-auth",'')
 
-        # 1. Verify token locally
-        # 2. If expired, refresh against client studio-api
-        # (Need to add client studio-api to default config)
-        # (Need to add token-exchange option to default values.yaml)
-        file_active = open(os.path.expanduser('~/.scaleout/active'), 'r')
-        active_remote = file_active.read()
-        file_active.close()
-        active_dir = os.path.expanduser('~/.scaleout/'+active_remote)
-        file_token = open(active_dir+'/token', 'r')
-        file_refresh_token = open(active_dir+'/refresh_token', 'r')
-        file_public_key = open(active_dir+'/public_key', 'r')
-        file_host_url = open(active_dir+'/host', 'r')
-        access_token = file_token.read()
-        refresh_token = file_refresh_token.read()
-        public_key = file_public_key.read()
-        host_url = file_host_url.read()
-        file_token.close()
-        file_refresh_token.close()
-        file_public_key.close()
-        file_host_url.close()
-
-        token = sauth.verify_or_refresh_jwt_token(active_remote,
-                                                 access_token,
-                                                 refresh_token,
-                                                 public_key,
-                                                 host_url)
+        token = sauth.get_token()
 
         self.auth_headers = {'Authorization': 'Token {}'.format(token)}
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -23,6 +23,7 @@ setup(
         "six>=1.14.0",
         "python-slugify",
         "prettytable",
+        "pyjwt",
     ],
     license="Copyright Scaleout Systems AB. See license for details",
     zip_safe=False,

--- a/components/studio/api/views.py
+++ b/components/studio/api/views.py
@@ -20,7 +20,7 @@ class ModelList(GenericViewSet, CreateModelMixin, RetrieveModelMixin, UpdateMode
     permission_classes = (IsAuthenticated,)
     serializer_class = MLModelSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ['id','name', 'tag']
+    filterset_fields = ['id','name', 'tag', 'project']
 
     def get_queryset(self):
         """
@@ -154,7 +154,7 @@ class ProjectList(generics.ListAPIView, GenericViewSet, CreateModelMixin, Retrie
     permission_classes = (IsAuthenticated,)
     serializer_class = ProjectSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ['name']
+    filterset_fields = ['name', 'slug']
 
     def get_queryset(self):
         """

--- a/components/studio/api/views.py
+++ b/components/studio/api/views.py
@@ -104,7 +104,7 @@ class DeploymentInstanceList(GenericViewSet, CreateModelMixin, RetrieveModelMixi
         except:
             return HttpResponse('Deployment environment {} not found.'.format(environment), status=404)
 
-        instance = DeploymentInstance(model=mod, deployment=dep)
+        instance = DeploymentInstance(model=mod, deployment=dep, created_by=request.user)
         instance.save()
         
         return HttpResponse('ok', status=200)

--- a/components/studio/deployments/views.py
+++ b/components/studio/deployments/views.py
@@ -55,7 +55,7 @@ def deploy(request, id):
     if request.method == 'POST':
         deployment = request.POST.get('deployment', None)
         definition = DeploymentDefinition.objects.get(name=deployment)
-        instance = DeploymentInstance(model=model, deployment=definition)
+        instance = DeploymentInstance(model=model, deployment=definition, created_by=request.user)
         instance.save()
         # return JsonResponse({"code": "201"})
 

--- a/components/studio/labs/helpers.py
+++ b/components/studio/labs/helpers.py
@@ -72,7 +72,7 @@ def keycloak_get_clients(kc, payload):
         return clients
     else:
         print('Failed to fetch clients.')
-        print('Request returned status: '+res.status_code)
+        print('Request returned status: '+str(res.status_code))
         print(res.text)
 
 def keycloak_delete_client(kc, client_id):
@@ -86,7 +86,7 @@ def keycloak_delete_client(kc, client_id):
         return True
     else:
         print('Failed to delete client: '+client_id)
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
 
 def keycloak_create_client(kc, client_id, base_url, root_url=[], redirectUris=[]):
@@ -105,7 +105,7 @@ def keycloak_create_client(kc, client_id, base_url, root_url=[], redirectUris=[]
         return True
     else:
         print('Failed to create new client.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -117,7 +117,7 @@ def keycloak_get_client_secret(kc, client_nid):
         if 'value' in res:
             return res['value']
     print('Failed to get client secret for client: '+client_nid)
-    print('Status code: '+res.status_code)
+    print('Status code: '+str(res.status_code))
     print(res.text)
 
 def keycloak_create_client_scope(kc, scope_name, protocol='openid-connect', 
@@ -127,12 +127,12 @@ def keycloak_create_client_scope(kc, scope_name, protocol='openid-connect',
     client_scope_body = {'name': scope_name,
                         'protocol': 'openid-connect',
                         'attributes': {'include.in.token.scope': 'true', 'display.on.consent.screen': 'true'}}
-    res = r.post(client_scope_url, client_scope_body)
+    res = r.post(client_scope_url, json=client_scope_body, headers={'Authorization': 'bearer '+kc.token})
     if res:
         return True
     else:
         print('Failed to create client scope '+scope_name)
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -148,7 +148,7 @@ def keycloak_get_client_scope_id(kc, scope_name):
         return scope_id
     else:
         print('Failed to get client scopes.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -169,7 +169,7 @@ def keycloak_create_scope_mapper(kc, scope_id, mapper_name, client_audience):
         return True
     else:
         print('Failed to create scope mapper.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -180,7 +180,7 @@ def keycloak_add_scope_to_client(kc, client_id, scope_id):
         return True
     else:
         print('Failed to add scope to client.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False        
 
@@ -192,7 +192,7 @@ def keycloak_create_client_role(kc, client_nid, role_name):
         return True
     else:
         print('Failed to create client role.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -201,7 +201,7 @@ def keycloak_get_user_id(kc, username):
     res = r.get(get_users_url, params={'username': username}, headers={'Authorization': 'bearer '+kc.token}).json()
     if not res:
         print('Failed to get user id.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
     if len(res) != 1:
@@ -220,7 +220,7 @@ def keycloak_get_client_role_id(kc, role_name, client_nid):
                 return role['id']
     else:
         print('Failed to get client role id.')
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 
@@ -240,7 +240,7 @@ def keycloak_add_user_to_client_role(kc, client_nid, username, role_name):
         return True
     else:
         print('Failed to add user {} to client role {}.'.format(username, role_name))
-        print('Status code: '+res.status_code)
+        print('Status code: '+str(res.status_code))
         print(res.text)
         return False
 

--- a/components/studio/labs/helpers.py
+++ b/components/studio/labs/helpers.py
@@ -4,183 +4,283 @@ import requests as r
 
 logger = logging.getLogger(__file__)
 
-def keycloak_auth(client_id, client_secret, token_url):
+class KeycloakInit:
+    admin_url: str
+    realm: str
+    token: str
+    def __init__(self, admin_url, realm, token):
+        self.admin_url = admin_url
+        self.realm = realm
+        self.token = token
+
+def keycloak_user_auth(username, password, client_id, admin_url, realm):
+    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
+    req = {'client_id': client_id,
+           'grant_type': 'password',
+           'username': username,
+           'password': password}
+    res = r.post(token_url, data=req)
+    if res:
+        res = res.json()
+    else:
+        print('Failed to authenticate.')
+        print(res.text)
+    if 'access_token' in res:
+        return res['access_token']
+    else:
+        print('User: '+username+' denied access to client: '+client_id)
+        return False
+
+
+def keycloak_client_auth(client_id, client_secret, admin_url, realm):
+    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
     payload = 'grant_type=client_credentials'
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-    response = r.request('POST', token_url, headers=headers, data=payload,
-                                auth=r.auth.HTTPBasicAuth(client_id, client_secret))
+    res = r.post(token_url, headers=headers,
+                            data=payload,
+                            auth=r.auth.HTTPBasicAuth(client_id, client_secret)) 
+    if res:
+        res = res.json()
+    else:
+        print('Failed to authenticate.')
+        print(res.text)
+    if 'access_token' in res:
+        return res['access_token']
+    else:
+        print('Failed to authenticate as client: '+client_id)
+        return False
 
-    token =response.json()['access_token']
-    return token
-
-def delete_keycloak_client(client_id):
-    realm = settings.KC_REALM
-    # user = settings.KC_USERNAME
-    # password = settings.KC_PASS
-    admin_url = settings.KC_ADMIN_URL
-    # Get Token
-
-    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
-
-    # req = {'client_id': 'admin-cli',
-    #       'grant_type': 'password',
-    #       'username': user,
-    #       'password': password}
-
-    # res = r.post(token_url, data=req)
-
-    # token =res.json()['access_token']
-    token = keycloak_auth(settings.OIDC_RP_CLIENT_ID, settings.OIDC_RP_CLIENT_SECRET, token_url)
-
-    get_clients_url = '{}/admin/realms/{}/clients'.format(admin_url, realm)
-    res = r.get(get_clients_url, headers={'Authorization': 'bearer '+token})
-    clients = res.json()
-    lab_client = []
-    for client in clients:
-        if client['clientId'] == client_id:
-            lab_client = client
-    # Create client
-    delete_client_url = '{}/admin/realms/{}/clients/{}'.format(admin_url, realm, lab_client['id'])
-
-    res = r.delete(delete_client_url, headers={'Authorization': 'bearer '+token})
-
-def create_keycloak_client(request, req_user, session):
-
-    HOST = settings.DOMAIN
-    RELEASE_NAME = str(session.slug)
-
-    URL = 'https://'+RELEASE_NAME+'.'+HOST
-
+def keycloak_init():
     admin_url = settings.KC_ADMIN_URL
     realm = settings.KC_REALM
+    token = keycloak_client_auth(settings.OIDC_RP_CLIENT_ID,
+                                 settings.OIDC_RP_CLIENT_SECRET,
+                                 admin_url,
+                                 realm)
+    if token:
+        kc = KeycloakInit(admin_url, realm, token)
+        return kc
+    else:
+        print('Failed to init Keycloak auth')
+        return False
 
-    # user = settings.KC_USERNAME
-    # password = settings.KC_PASS
+def keycloak_get_clients(kc, payload):
+    get_clients_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
+    res = r.get(get_clients_url, headers={'Authorization': 'bearer '+kc.token}, params=payload)
+    if res:
+        clients = res.json() 
+        return clients
+    else:
+        print('Failed to fetch clients.')
+        print('Request returned status: '+res.status_code)
+        print(res.text)
 
-    # Get Token
-    
-    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
+def keycloak_delete_client(kc, client_id):
+    # Get id (not clientId)
+    clients = keycloak_get_clients(kc, {'clientId': client_id})
+    client_nid = clients[0]['id']
+    # Delete client
+    delete_client_url = '{}/admin/realms/{}/clients/{}'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.delete(delete_client_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to delete client: '+client_id)
+        print('Status code: '+res.status_code)
+        print(res.text)
 
-    # req = {'client_id': 'admin-cli',
-    #       'grant_type': 'password',
-    #       'username': user,
-    #       'password': password}
+def keycloak_create_client(kc, client_id, base_url, root_url=[], redirectUris=[]):
+    if not root_url:
+        root_url = base_url
+    if not redirectUris:
+        redirectUris = [base_url+'/*']
+    create_client_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
 
-    # res = r.post(token_url, data=req)
+    client_rep = {'clientId': client_id,
+                  'baseUrl': base_url,
+                  'rootUrl': root_url,
+                  'redirectUris': redirectUris}
+    res = r.post(create_client_url, json=client_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create new client.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
 
-    # token =res.json()['access_token']
-    token = keycloak_auth(settings.OIDC_RP_CLIENT_ID, settings.OIDC_RP_CLIENT_SECRET, token_url)
-
-    # Create client
-    create_client_url = '{}/admin/realms/{}/clients'.format(admin_url, realm)
-
-    client_rep = {'clientId': RELEASE_NAME,
-                  'baseUrl': URL,
-                  'rootUrl': URL,
-                  'redirectUris': [URL+'/*']}
-    print(client_rep)
-    print(create_client_url)
-    res = r.post(create_client_url, json=client_rep, headers={'Authorization': 'bearer '+token})
+def keycloak_get_client_secret(kc, client_nid):
+    get_client_secret_url = '{}/admin/realms/{}/clients/{}/client-secret'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.get(get_client_secret_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        res = res.json()
+        if 'value' in res:
+            return res['value']
+    print('Failed to get client secret for client: '+client_nid)
+    print('Status code: '+res.status_code)
     print(res.text)
-    # print(dir(res))
 
-    # Fetch client info
-
-    get_clients_url = '{}/admin/realms/{}/clients'.format(admin_url, realm)
-    res = r.get(get_clients_url, headers={'Authorization': 'bearer '+token})
-    clients = res.json()
-    lab_client = []
-    for client in clients:
-        if client['clientId'] == RELEASE_NAME:
-            lab_client = client
-
-    # print(lab_client)
-    get_client_secret_url = '{}/admin/realms/{}/clients/{}/client-secret'.format(admin_url, realm, lab_client['id'])
-    res = r.get(get_client_secret_url, headers={'Authorization': 'bearer '+token})
-    client_secret = res.json()['value']
-    print(client_secret)
-
-    # Create client scope
-    create_client_scope_url = '{}/admin/realms/{}/client-scopes'.format(admin_url, realm)
-    client_scope_body = {'name': RELEASE_NAME+'-scope'}
-    res = r.post(create_client_scope_url, client_scope_body)
-
-    # Create client scope
-    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(admin_url, realm)
-    # protocolMapper = {'name': RELEASE_NAME+'audience'}
-    client_scope_body = {'name': RELEASE_NAME+'-scope',
+def keycloak_create_client_scope(kc, scope_name, protocol='openid-connect', 
+                                                 attributes={'include.in.token.scope': 'true',
+                                                             'display.on.consent.screen': 'true'}):
+    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
+    client_scope_body = {'name': scope_name,
                         'protocol': 'openid-connect',
                         'attributes': {'include.in.token.scope': 'true', 'display.on.consent.screen': 'true'}}
+    res = r.post(client_scope_url, client_scope_body)
+    if res:
+        return True
+    else:
+        print('Failed to create client scope '+scope_name)
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
 
+def keycloak_get_client_scope_id(kc, scope_name):
+    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
+    res = r.get(client_scope_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        scopes = res.json()
+        scope_id = None
+        for scope in scopes:
+            if scope['name'] == scope_name:
+                scope_id = scope['id']
+        return scope_id
+    else:
+        print('Failed to get client scopes.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
 
-
-    res = r.post(client_scope_url, json=client_scope_body, headers={'Authorization': 'bearer '+token})
-    print(res.text)
-    # Create mapper
-
-    # Get scope id
-    res = r.get(client_scope_url, headers={'Authorization': 'bearer '+token})
-    scopes = res.json()
-    scope_id = None
-    for scope in scopes:
-        if scope['name'] == RELEASE_NAME+'-scope':
-            scope_id = scope['id']
-
-    print(scope_id)
-    # /{realm}/client-scopes/{id}/protocol-mappers/models
-    create_client_scope_mapper_url = '{}/admin/realms/{}/client-scopes/{}/protocol-mappers/models'.format(admin_url, realm, scope_id)
-    scope_mapper = {'name': RELEASE_NAME+'-audience',
+def keycloak_create_scope_mapper(kc, scope_id, mapper_name, client_audience):
+    create_client_scope_mapper_url = '{}/admin/realms/{}/client-scopes/{}/protocol-mappers/models'.format(kc.admin_url, kc.realm, scope_id)
+    scope_mapper = {'name': mapper_name,
                     'protocol': 'openid-connect',
                     'protocolMapper': 'oidc-audience-mapper',
                     'consentRequired': False,
-                    'config': {'included.client.audience': RELEASE_NAME, 'id.token.claim': 'false', 'access.token.claim': 'true'}}
+                    'config': {'included.client.audience': client_audience,
+                               'id.token.claim': 'false',
+                               'access.token.claim': 'true'}}
 
-    res = r.post(create_client_scope_mapper_url, json=scope_mapper, headers={'Authorization': 'bearer '+token})
-    print(res.text)
-    
-    # Add the scope to the client
-    get_client_scopes_url = '{}/admin/realms/{}/client-scopes'.format(admin_url, realm)
-    client_scopes = r.get(get_client_scopes_url, headers={'Authorization': 'bearer '+token}).json()
-    scope_id = None
-    for scope in client_scopes:
-        if scope['name'] == RELEASE_NAME+'-scope':
-            print(scope)
-            scope_id = scope['id']
+    res = r.post(create_client_scope_mapper_url,
+                 json=scope_mapper,
+                 headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create scope mapper.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
 
-    add_default_scope_url = '{}/admin/realms/{}/clients/{}/default-client-scopes/{}'.format(admin_url, realm, lab_client['id'], scope_id)
-    res = r.put(add_default_scope_url, headers={'Authorization': 'bearer '+token})
-    
-    # Create client role
-    # POST /{realm}/clients/{id}/roles
-    add_client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(admin_url, realm, lab_client['id'])
-    role_rep = {'name': RELEASE_NAME+'-role'}
-    r.post(add_client_role_url, json=role_rep, headers={'Authorization': 'bearer '+token})
-    
+def keycloak_add_scope_to_client(kc, client_id, scope_id):
+    add_default_scope_url = '{}/admin/realms/{}/clients/{}/default-client-scopes/{}'.format(kc.admin_url, kc.realm, client_id, scope_id)
+    res = r.put(add_default_scope_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to add scope to client.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False        
 
-    # Get user id
-    get_users_url =  '{}/admin/realms/{}/users'.format(admin_url, realm)
-    kc_user = r.get(get_users_url, params={'username': req_user}, headers={'Authorization': 'bearer '+token}).json()
-    # print(user.text)
-    kc_user = kc_user[0]
-    print(kc_user)
-    # Add user to client role
-    #  /{realm}/users/{id}/role-mappings/clients/{client}
-    user_id = kc_user['id']#'68e81a02-c680-45c2-a22d-67922cf90165'
-    print(user_id)
-    add_user_to_role_url = '{}/admin/realms/{}/users/{}/role-mappings/clients/{}'.format(admin_url,
-                                                                                          realm,
-                                                                                          user_id,
-                                                                                          lab_client['id'])
+def keycloak_create_client_role(kc, client_nid, role_name):
+    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
+    role_rep = {'name': role_name}
+    res = r.post(client_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create client role.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
+
+def keycloak_get_user_id(kc, username):
+    get_users_url =  '{}/admin/realms/{}/users'.format(kc.admin_url, kc.realm)
+    res = r.get(get_users_url, params={'username': username}, headers={'Authorization': 'bearer '+kc.token}).json()
+    if not res:
+        print('Failed to get user id.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
+    if len(res) != 1:
+        print("Didn't find user: "+username+" in realm: "+kc.realm)
+        return False
+    res = res[0]
+    return res['id']
+
+def keycloak_get_client_role_id(kc, role_name, client_nid):
+    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.get(client_role_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        client_roles = res.json()
+        for role in client_roles:
+            if role['name'] == role_name:
+                return role['id']
+    else:
+        print('Failed to get client role id.')
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
+
+def keycloak_add_user_to_client_role(kc, client_nid, username, role_name):
+    user_id = keycloak_get_user_id(kc, username)
+    add_user_to_role_url = '{}/admin/realms/{}/users/{}/role-mappings/clients/{}'.format(kc.admin_url,
+                                                                                         kc.realm,
+                                                                                         user_id,
+                                                                                         client_nid)
     
     # Get role id
-    client_roles = r.get(add_client_role_url, headers={'Authorization': 'bearer '+token}).json()
-    for role in client_roles:
-        if role['name'] == RELEASE_NAME+'-role':
-            role_id = role['id']
+    role_id = keycloak_get_client_role_id(kc, role_name, client_nid)
 
-    role_rep = [{'name': RELEASE_NAME+'-role', 'id': role_id}]
-    r.post(add_user_to_role_url, json=role_rep, headers={'Authorization': 'bearer '+token})
+    role_rep = [{'name': role_name, 'id': role_id}]
+    res = r.post(add_user_to_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to add user {} to client role {}.'.format(username, role_name))
+        print('Status code: '+res.status_code)
+        print(res.text)
+        return False
 
+def setup_labs_client(request, req_user, session):
+
+    HOST = settings.DOMAIN
+    RELEASE_NAME = str(session.slug)
+    
+    URL = 'https://'+RELEASE_NAME+'.'+HOST
+
+    kc = keycloak_init()
+
+    # Create client
+    if not keycloak_create_client(kc, RELEASE_NAME, URL):
+        return False
+
+    # Fetch client info
+    clients = keycloak_get_clients(kc, {'clientId': RELEASE_NAME})
+    client_nid = clients[0]['id']
+    client_secret = keycloak_get_client_secret(kc, client_nid)
+
+    # Create client scope
+    if not keycloak_create_client_scope(kc, RELEASE_NAME+'-scope'):
+        return False
+
+    # __Create mapper__
+    # Get scope id
+    scope_id = keycloak_get_client_scope_id(kc, RELEASE_NAME+'-scope')
+    #Create mapper
+    keycloak_create_scope_mapper(kc, scope_id, RELEASE_NAME+'-audience', RELEASE_NAME)
+    # _________________
+
+    # Add the scope to the client
+    keycloak_add_scope_to_client(kc, client_nid, scope_id)
+    
+    # Create client role
+    keycloak_create_client_role(kc, client_nid, RELEASE_NAME+'-role')
+
+    # Add user to client role
+    keycloak_add_user_to_client_role(kc, client_nid, req_user, RELEASE_NAME+'-role')
 
     return RELEASE_NAME, client_secret
 
@@ -188,7 +288,7 @@ def create_session_resources(request, user, session, prefs, project):
 
     print("1; going for the dispatch!")
 
-    client_id, client_secret = create_keycloak_client(request, user, session)
+    client_id, client_secret = setup_labs_client(request, user, session)
 
     parameters = {'release': str(session.slug),
                   'chart': session.chart,
@@ -216,7 +316,8 @@ def delete_session_resources(session):
     print("trying to delete {}".format(session.slug))
     parameters = {'release': str(session.slug)}
     retval = r.get(settings.CHART_CONTROLLER_URL + '/delete', parameters)
-    delete_keycloak_client(str(session.slug))
+    kc = keycloak_init()
+    keycloak_delete_client(kc, str(session.slug))
     if retval:
         print('delete success!')
         return True

--- a/components/studio/labs/helpers.py
+++ b/components/studio/labs/helpers.py
@@ -1,306 +1,20 @@
 from django.conf import settings
 import logging
 import requests as r
+import modules.keycloak_lib as keylib
 
 logger = logging.getLogger(__file__)
 
-class KeycloakInit:
-    admin_url: str
-    realm: str
-    token: str
-    def __init__(self, admin_url, realm, token):
-        self.admin_url = admin_url
-        self.realm = realm
-        self.token = token
-
-def keycloak_user_auth(username, password, client_id, admin_url, realm):
-    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
-    req = {'client_id': client_id,
-           'grant_type': 'password',
-           'username': username,
-           'password': password}
-    res = r.post(token_url, data=req)
-    if res:
-        res = res.json()
-    else:
-        print('Failed to authenticate.')
-        print(res.text)
-    if 'access_token' in res:
-        return res['access_token']
-    else:
-        print('User: '+username+' denied access to client: '+client_id)
-        return False
-
-
-def keycloak_client_auth(client_id, client_secret, admin_url, realm):
-    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
-    payload = 'grant_type=client_credentials'
-    headers = {'Content-Type': 'application/x-www-form-urlencoded'}
-    res = r.post(token_url, headers=headers,
-                            data=payload,
-                            auth=r.auth.HTTPBasicAuth(client_id, client_secret)) 
-    if res:
-        res = res.json()
-    else:
-        print('Failed to authenticate.')
-        print(res.text)
-    if 'access_token' in res:
-        return res['access_token']
-    else:
-        print('Failed to authenticate as client: '+client_id)
-        return False
-
-def keycloak_init():
-    admin_url = settings.KC_ADMIN_URL
-    realm = settings.KC_REALM
-    token = keycloak_client_auth(settings.OIDC_RP_CLIENT_ID,
-                                 settings.OIDC_RP_CLIENT_SECRET,
-                                 admin_url,
-                                 realm)
-    if token:
-        kc = KeycloakInit(admin_url, realm, token)
-        return kc
-    else:
-        print('Failed to init Keycloak auth')
-        return False
-
-def keycloak_get_clients(kc, payload):
-    get_clients_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
-    res = r.get(get_clients_url, headers={'Authorization': 'bearer '+kc.token}, params=payload)
-    if res:
-        clients = res.json() 
-        return clients
-    else:
-        print('Failed to fetch clients.')
-        print('Request returned status: '+str(res.status_code))
-        print(res.text)
-
-def keycloak_delete_client(kc, client_id):
-    # Get id (not clientId)
-    clients = keycloak_get_clients(kc, {'clientId': client_id})
-    client_nid = clients[0]['id']
-    # Delete client
-    delete_client_url = '{}/admin/realms/{}/clients/{}'.format(kc.admin_url, kc.realm, client_nid)
-    res = r.delete(delete_client_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to delete client: '+client_id)
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-
-def keycloak_create_client(kc, client_id, base_url, root_url=[], redirectUris=[]):
-    if not root_url:
-        root_url = base_url
-    if not redirectUris:
-        redirectUris = [base_url+'/*']
-    create_client_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
-
-    client_rep = {'clientId': client_id,
-                  'baseUrl': base_url,
-                  'rootUrl': root_url,
-                  'redirectUris': redirectUris}
-    res = r.post(create_client_url, json=client_rep, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to create new client.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_get_client_secret(kc, client_nid):
-    get_client_secret_url = '{}/admin/realms/{}/clients/{}/client-secret'.format(kc.admin_url, kc.realm, client_nid)
-    res = r.get(get_client_secret_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        res = res.json()
-        if 'value' in res:
-            return res['value']
-    print('Failed to get client secret for client: '+client_nid)
-    print('Status code: '+str(res.status_code))
-    print(res.text)
-
-def keycloak_create_client_scope(kc, scope_name, protocol='openid-connect', 
-                                                 attributes={'include.in.token.scope': 'true',
-                                                             'display.on.consent.screen': 'true'}):
-    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
-    client_scope_body = {'name': scope_name,
-                        'protocol': 'openid-connect',
-                        'attributes': {'include.in.token.scope': 'true', 'display.on.consent.screen': 'true'}}
-    res = r.post(client_scope_url, json=client_scope_body, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to create client scope '+scope_name)
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_get_client_scope_id(kc, scope_name):
-    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
-    res = r.get(client_scope_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        scopes = res.json()
-        scope_id = None
-        for scope in scopes:
-            if scope['name'] == scope_name:
-                scope_id = scope['id']
-        return scope_id
-    else:
-        print('Failed to get client scopes.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_delete_client_scope(kc, scope_id):
-    # /{realm}/client-scopes/{id}
-    client_scope_url = '{}/admin/realms/{}/client-scopes/{}'.format(kc.admin_url, kc.realm, scope_id)
-    res = r.delete(client_scope_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to delete client scope '+scope_id)
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_create_scope_mapper(kc, scope_id, mapper_name, client_audience):
-    create_client_scope_mapper_url = '{}/admin/realms/{}/client-scopes/{}/protocol-mappers/models'.format(kc.admin_url, kc.realm, scope_id)
-    scope_mapper = {'name': mapper_name,
-                    'protocol': 'openid-connect',
-                    'protocolMapper': 'oidc-audience-mapper',
-                    'consentRequired': False,
-                    'config': {'included.client.audience': client_audience,
-                               'id.token.claim': 'false',
-                               'access.token.claim': 'true'}}
-
-    res = r.post(create_client_scope_mapper_url,
-                 json=scope_mapper,
-                 headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to create scope mapper.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_add_scope_to_client(kc, client_id, scope_id):
-    add_default_scope_url = '{}/admin/realms/{}/clients/{}/default-client-scopes/{}'.format(kc.admin_url, kc.realm, client_id, scope_id)
-    res = r.put(add_default_scope_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to add scope to client.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False        
-
-def keycloak_create_client_role(kc, client_nid, role_name):
-    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
-    role_rep = {'name': role_name}
-    res = r.post(client_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to create client role.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_get_user_id(kc, username):
-    get_users_url =  '{}/admin/realms/{}/users'.format(kc.admin_url, kc.realm)
-    res = r.get(get_users_url, params={'username': username}, headers={'Authorization': 'bearer '+kc.token}).json()
-    if not res:
-        print('Failed to get user id.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-    if len(res) != 1:
-        print("Didn't find user: "+username+" in realm: "+kc.realm)
-        return False
-    res = res[0]
-    return res['id']
-
-def keycloak_get_client_role_id(kc, role_name, client_nid):
-    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
-    res = r.get(client_role_url, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        client_roles = res.json()
-        for role in client_roles:
-            if role['name'] == role_name:
-                return role['id']
-    else:
-        print('Failed to get client role id.')
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def keycloak_add_user_to_client_role(kc, client_nid, username, role_name):
-    user_id = keycloak_get_user_id(kc, username)
-    add_user_to_role_url = '{}/admin/realms/{}/users/{}/role-mappings/clients/{}'.format(kc.admin_url,
-                                                                                         kc.realm,
-                                                                                         user_id,
-                                                                                         client_nid)
-    
-    # Get role id
-    role_id = keycloak_get_client_role_id(kc, role_name, client_nid)
-
-    role_rep = [{'name': role_name, 'id': role_id}]
-    res = r.post(add_user_to_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
-    if res:
-        return True
-    else:
-        print('Failed to add user {} to client role {}.'.format(username, role_name))
-        print('Status code: '+str(res.status_code))
-        print(res.text)
-        return False
-
-def setup_labs_client(request, req_user, session):
-
-    HOST = settings.DOMAIN
-    RELEASE_NAME = str(session.slug)
-    
-    URL = 'https://'+RELEASE_NAME+'.'+HOST
-
-    kc = keycloak_init()
-
-    # Create client
-    if not keycloak_create_client(kc, RELEASE_NAME, URL):
-        return False
-
-    # Fetch client info
-    clients = keycloak_get_clients(kc, {'clientId': RELEASE_NAME})
-    client_nid = clients[0]['id']
-    client_secret = keycloak_get_client_secret(kc, client_nid)
-
-    # Create client scope
-    if not keycloak_create_client_scope(kc, RELEASE_NAME+'-scope'):
-        return False
-
-    # __Create mapper__
-    # Get scope id
-    scope_id = keycloak_get_client_scope_id(kc, RELEASE_NAME+'-scope')
-    #Create mapper
-    keycloak_create_scope_mapper(kc, scope_id, RELEASE_NAME+'-audience', RELEASE_NAME)
-    # _________________
-
-    # Add the scope to the client
-    keycloak_add_scope_to_client(kc, client_nid, scope_id)
-    
-    # Create client role
-    keycloak_create_client_role(kc, client_nid, RELEASE_NAME+'-role')
-
-    # Add user to client role
-    keycloak_add_user_to_client_role(kc, client_nid, req_user, RELEASE_NAME+'-role')
-
-    return RELEASE_NAME, client_secret
 
 def create_session_resources(request, user, session, prefs, project):
 
     print("1; going for the dispatch!")
 
-    client_id, client_secret = setup_labs_client(request, user, session)
+    HOST = settings.DOMAIN
+    RELEASE_NAME = str(session.slug)
+    
+    URL = 'https://'+RELEASE_NAME+'.'+HOST
+    client_id, client_secret = keylib.keycloak_setup_base_client(URL, RELEASE_NAME, user)
 
     parameters = {'release': str(session.slug),
                   'chart': session.chart,
@@ -329,11 +43,11 @@ def delete_session_resources(session):
     parameters = {'release': str(session.slug)}
     retval = r.get(settings.CHART_CONTROLLER_URL + '/delete', parameters)
     
-    kc = keycloak_init()
-    keycloak_delete_client(kc, str(session.slug))
+    kc = keylib.keycloak_init()
+    keylib.keycloak_delete_client(kc, str(session.slug))
     
-    scope_id = keycloak_get_client_scope_id(kc, str(session.slug)+'-scope')
-    keycloak_delete_client_scope(kc, scope_id)
+    scope_id = keylib.keycloak_get_client_scope_id(kc, str(session.slug)+'-scope')
+    keylib.keycloak_delete_client_scope(kc, scope_id)
 
     if retval:
         print('delete success!')

--- a/components/studio/models/views.py
+++ b/components/studio/models/views.py
@@ -25,6 +25,7 @@ def index(request):
 
 @login_required(login_url='/accounts/login')
 def list(request, user, project):
+    print(dir(request))
     template = 'models_list.html'
     project = Project.objects.filter(slug=project).first()
 

--- a/components/studio/modules/keycloak_lib.py
+++ b/components/studio/modules/keycloak_lib.py
@@ -1,0 +1,289 @@
+from django.conf import settings
+import requests as r
+
+class KeycloakInit:
+    admin_url: str
+    realm: str
+    token: str
+    def __init__(self, admin_url, realm, token):
+        self.admin_url = admin_url
+        self.realm = realm
+        self.token = token
+
+def keycloak_user_auth(username, password, client_id, admin_url, realm):
+    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
+    req = {'client_id': client_id,
+           'grant_type': 'password',
+           'username': username,
+           'password': password}
+    res = r.post(token_url, data=req)
+    if res:
+        res = res.json()
+    else:
+        print('Failed to authenticate.')
+        print(res.text)
+    if 'access_token' in res:
+        return res['access_token']
+    else:
+        print('User: '+username+' denied access to client: '+client_id)
+        return False
+
+
+def keycloak_client_auth(client_id, client_secret, admin_url, realm):
+    token_url = '{}/realms/{}/protocol/openid-connect/token'.format(admin_url, realm)
+    payload = 'grant_type=client_credentials'
+    headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+    res = r.post(token_url, headers=headers,
+                            data=payload,
+                            auth=r.auth.HTTPBasicAuth(client_id, client_secret)) 
+    if res:
+        res = res.json()
+    else:
+        print('Failed to authenticate.')
+        print(res.text)
+    if 'access_token' in res:
+        return res['access_token']
+    else:
+        print('Failed to authenticate as client: '+client_id)
+        return False
+
+def keycloak_init():
+    admin_url = settings.KC_ADMIN_URL
+    realm = settings.KC_REALM
+    token = keycloak_client_auth(settings.OIDC_RP_CLIENT_ID,
+                                 settings.OIDC_RP_CLIENT_SECRET,
+                                 admin_url,
+                                 realm)
+    if token:
+        kc = KeycloakInit(admin_url, realm, token)
+        return kc
+    else:
+        print('Failed to init Keycloak auth')
+        return False
+
+def keycloak_get_clients(kc, payload):
+    get_clients_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
+    res = r.get(get_clients_url, headers={'Authorization': 'bearer '+kc.token}, params=payload)
+    if res:
+        clients = res.json() 
+        return clients
+    else:
+        print('Failed to fetch clients.')
+        print('Request returned status: '+str(res.status_code))
+        print(res.text)
+
+def keycloak_delete_client(kc, client_id):
+    # Get id (not clientId)
+    clients = keycloak_get_clients(kc, {'clientId': client_id})
+    client_nid = clients[0]['id']
+    # Delete client
+    delete_client_url = '{}/admin/realms/{}/clients/{}'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.delete(delete_client_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to delete client: '+client_id)
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+
+def keycloak_create_client(kc, client_id, base_url, root_url=[], redirectUris=[]):
+    if not root_url:
+        root_url = base_url
+    if not redirectUris:
+        redirectUris = [base_url+'/*']
+    create_client_url = '{}/admin/realms/{}/clients'.format(kc.admin_url, kc.realm)
+
+    client_rep = {'clientId': client_id,
+                  'baseUrl': base_url,
+                  'rootUrl': root_url,
+                  'redirectUris': redirectUris}
+    res = r.post(create_client_url, json=client_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create new client.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_get_client_secret(kc, client_nid):
+    get_client_secret_url = '{}/admin/realms/{}/clients/{}/client-secret'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.get(get_client_secret_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        res = res.json()
+        if 'value' in res:
+            return res['value']
+    print('Failed to get client secret for client: '+client_nid)
+    print('Status code: '+str(res.status_code))
+    print(res.text)
+
+def keycloak_create_client_scope(kc, scope_name, protocol='openid-connect', 
+                                                 attributes={'include.in.token.scope': 'true',
+                                                             'display.on.consent.screen': 'true'}):
+    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
+    client_scope_body = {'name': scope_name,
+                        'protocol': 'openid-connect',
+                        'attributes': {'include.in.token.scope': 'true', 'display.on.consent.screen': 'true'}}
+    res = r.post(client_scope_url, json=client_scope_body, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create client scope '+scope_name)
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_get_client_scope_id(kc, scope_name):
+    client_scope_url = '{}/admin/realms/{}/client-scopes'.format(kc.admin_url, kc.realm)
+    res = r.get(client_scope_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        scopes = res.json()
+        scope_id = None
+        for scope in scopes:
+            if scope['name'] == scope_name:
+                scope_id = scope['id']
+        return scope_id
+    else:
+        print('Failed to get client scopes.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_delete_client_scope(kc, scope_id):
+    # /{realm}/client-scopes/{id}
+    client_scope_url = '{}/admin/realms/{}/client-scopes/{}'.format(kc.admin_url, kc.realm, scope_id)
+    res = r.delete(client_scope_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to delete client scope '+scope_id)
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_create_scope_mapper(kc, scope_id, mapper_name, client_audience):
+    create_client_scope_mapper_url = '{}/admin/realms/{}/client-scopes/{}/protocol-mappers/models'.format(kc.admin_url, kc.realm, scope_id)
+    scope_mapper = {'name': mapper_name,
+                    'protocol': 'openid-connect',
+                    'protocolMapper': 'oidc-audience-mapper',
+                    'consentRequired': False,
+                    'config': {'included.client.audience': client_audience,
+                               'id.token.claim': 'false',
+                               'access.token.claim': 'true'}}
+
+    res = r.post(create_client_scope_mapper_url,
+                 json=scope_mapper,
+                 headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create scope mapper.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_add_scope_to_client(kc, client_id, scope_id):
+    add_default_scope_url = '{}/admin/realms/{}/clients/{}/default-client-scopes/{}'.format(kc.admin_url, kc.realm, client_id, scope_id)
+    res = r.put(add_default_scope_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to add scope to client.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False        
+
+def keycloak_create_client_role(kc, client_nid, role_name):
+    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
+    role_rep = {'name': role_name}
+    res = r.post(client_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to create client role.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_get_user_id(kc, username):
+    get_users_url =  '{}/admin/realms/{}/users'.format(kc.admin_url, kc.realm)
+    res = r.get(get_users_url, params={'username': username}, headers={'Authorization': 'bearer '+kc.token}).json()
+    if not res:
+        print('Failed to get user id.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+    if len(res) != 1:
+        print("Didn't find user: "+username+" in realm: "+kc.realm)
+        return False
+    res = res[0]
+    return res['id']
+
+def keycloak_get_client_role_id(kc, role_name, client_nid):
+    client_role_url = '{}/admin/realms/{}/clients/{}/roles'.format(kc.admin_url, kc.realm, client_nid)
+    res = r.get(client_role_url, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        client_roles = res.json()
+        for role in client_roles:
+            if role['name'] == role_name:
+                return role['id']
+    else:
+        print('Failed to get client role id.')
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_add_user_to_client_role(kc, client_nid, username, role_name):
+    user_id = keycloak_get_user_id(kc, username)
+    add_user_to_role_url = '{}/admin/realms/{}/users/{}/role-mappings/clients/{}'.format(kc.admin_url,
+                                                                                         kc.realm,
+                                                                                         user_id,
+                                                                                         client_nid)
+    
+    # Get role id
+    role_id = keycloak_get_client_role_id(kc, role_name, client_nid)
+
+    role_rep = [{'name': role_name, 'id': role_id}]
+    res = r.post(add_user_to_role_url, json=role_rep, headers={'Authorization': 'bearer '+kc.token})
+    if res:
+        return True
+    else:
+        print('Failed to add user {} to client role {}.'.format(username, role_name))
+        print('Status code: '+str(res.status_code))
+        print(res.text)
+        return False
+
+def keycloak_setup_base_client(base_url, client_id, username):
+
+    kc = keycloak_init()
+
+    # Create client
+    if not keycloak_create_client(kc, client_id, base_url):
+        return False
+
+    # Fetch client info
+    clients = keycloak_get_clients(kc, {'clientId': client_id})
+    client_nid = clients[0]['id']
+    client_secret = keycloak_get_client_secret(kc, client_nid)
+
+    # Create client scope
+    if not keycloak_create_client_scope(kc, client_id+'-scope'):
+        return False
+
+    # __Create mapper__
+    # Get scope id
+    scope_id = keycloak_get_client_scope_id(kc, client_id+'-scope')
+    #Create mapper
+    keycloak_create_scope_mapper(kc, scope_id, client_id+'-audience', client_id)
+    # _________________
+
+    # Add the scope to the client
+    keycloak_add_scope_to_client(kc, client_nid, scope_id)
+    
+    # Create client role
+    keycloak_create_client_role(kc, client_nid, client_id+'-role')
+
+    # Add user to client role
+    keycloak_add_user_to_client_role(kc, client_nid, username, client_id+'-role')
+
+    return client_id, client_secret

--- a/components/studio/projects/helpers.py
+++ b/components/studio/projects/helpers.py
@@ -24,20 +24,7 @@ def urlify(s):
 
 def create_settings_file(project, username, token):
     proj_settings = dict()
-    proj_settings['auth_url'] = os.path.join('https://'+settings.DOMAIN, 'api/api-token-auth')
-    proj_settings['access_key'] = decrypt_key(project.project_key)
-    proj_settings['username'] = username
-
-    kc = keylib.keycloak_init()
-    user_id = keylib.keycloak_get_user_id(kc, username)
-    token, refresh_token, token_url, public_key = keylib.keycloak_token_exchange_studio(kc, user_id)
-
-    proj_settings['token'] = token
-    proj_settings['refresh_token'] = refresh_token
-    proj_settings['token_url'] = token_url
-    proj_settings['token_public_key'] = public_key
-    proj_settings['so_domain_name'] = settings.DOMAIN
-    
+       
     proj_settings['Project'] = dict()
     proj_settings['Project']['project_name'] = project.name
     proj_settings['Project']['project_slug'] = project.slug

--- a/components/studio/projects/helpers.py
+++ b/components/studio/projects/helpers.py
@@ -27,7 +27,15 @@ def create_settings_file(project, username, token):
     proj_settings['auth_url'] = os.path.join('https://'+settings.DOMAIN, 'api/api-token-auth')
     proj_settings['access_key'] = decrypt_key(project.project_key)
     proj_settings['username'] = username
+
+    kc = keylib.keycloak_init()
+    user_id = keylib.keycloak_get_user_id(kc, username)
+    token, refresh_token, token_url, public_key = keylib.keycloak_token_exchange_studio(kc, user_id)
+
     proj_settings['token'] = token
+    proj_settings['refresh_token'] = refresh_token
+    proj_settings['token_url'] = token_url
+    proj_settings['token_public_key'] = public_key
     proj_settings['so_domain_name'] = settings.DOMAIN
     
     proj_settings['Project'] = dict()

--- a/components/studio/projects/jobs.py
+++ b/components/studio/projects/jobs.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+import os
+from pathlib import Path
 
 job_template = '''apiVersion: batch/v1
 kind: Job
@@ -70,10 +72,26 @@ def __generate_and_apply_configmaps(project):
     from kubernetes.client.rest import ApiException
     from pprint import pprint
 
+    
+
     if settings.EXTERNAL_KUBECONF:
         config.load_kube_config('cluster.conf')
     else:
-        config.load_incluster_config()
+        # adjust k8s service account paths if running inside telepresence
+        if 'TELEPRESENCE_ROOT' in os.environ:
+            from kubernetes.config.incluster_config import (SERVICE_CERT_FILENAME,
+                                                      SERVICE_TOKEN_FILENAME,
+                                                      InClusterConfigLoader)
+            token_filename = Path(os.getenv('TELEPRESENCE_ROOT', '/')
+                                  ) / Path(SERVICE_TOKEN_FILENAME).relative_to('/')
+            cert_filename = Path(os.getenv('TELEPRESENCE_ROOT', '/')
+                                ) / Path(SERVICE_CERT_FILENAME).relative_to('/')
+
+            InClusterConfigLoader(
+                token_filename=token_filename, cert_filename=cert_filename
+            ).load_and_set()
+        else:
+            config.load_incluster_config()
 
     api = client.CoreV1Api()
 
@@ -131,7 +149,20 @@ def start_job(definition):
     if settings.EXTERNAL_KUBECONF:
         config.load_kube_config('cluster.conf')
     else:
-        config.load_incluster_config()
+        if 'TELEPRESENCE_ROOT' in os.environ:
+            from kubernetes.config.incluster_config import (SERVICE_CERT_FILENAME,
+                                                      SERVICE_TOKEN_FILENAME,
+                                                      InClusterConfigLoader)
+            token_filename = Path(os.getenv('TELEPRESENCE_ROOT', '/')
+                                  ) / Path(SERVICE_TOKEN_FILENAME).relative_to('/')
+            cert_filename = Path(os.getenv('TELEPRESENCE_ROOT', '/')
+                                ) / Path(SERVICE_CERT_FILENAME).relative_to('/')
+
+            InClusterConfigLoader(
+                token_filename=token_filename, cert_filename=cert_filename
+            ).load_and_set()
+        else:
+            config.load_incluster_config()
 
     api = client.BatchV1Api()
 

--- a/components/studio/requirements.txt
+++ b/components/studio/requirements.txt
@@ -33,3 +33,4 @@ django-bootstrap-modal-forms==1.5.0
 django-yamlfield==1.0.3
 Markdown==3.2.1
 mozilla-django-oidc
+pyjwt

--- a/components/studio/studio/KCRFbackend.py
+++ b/components/studio/studio/KCRFbackend.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import User
+from rest_framework import authentication
+from rest_framework import exceptions
+from django.conf import settings
+import modules.keycloak_lib as keylib
+import jwt
+
+class KeycloakAuthentication(authentication.BaseAuthentication):
+    def authenticate(self, request):
+        token_str = request.META['HTTP_AUTHORIZATION']
+        access_token = token_str.replace('Token ', '')
+        public_key = b'-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhJMHP2WFMfUGJ1NYRU2JOdorNC96iIdWljLK4v0CjnVi3jRnIBQsnPMB6n1e7Iju2jB0R5gZkWFfhVxnlnJAMyYVZG1/VB/uNL84hywCedFXe3sPj+DUfhZpGirOjGnbtxhdY9qxsYo97H++APNv78RMf3bD04MeRZksxkcJ0SKDJYuXuvPuLdVjwLTSuhY4VJiQcMRrB9DY5ZoQhJMK4fedXOlks1u1IO/w/ArMRl5NLNe18vX4y5r0aGb+PpeCH14YdOvD08NJ3USA7ZOiOKj70xb+SA+lOPBfqU3ijfQe3SbBF9mhdkwSISJIcoNYb8rjNH80ZkoMenh+rRE+wwIDAQAB\n-----END PUBLIC KEY-----'
+        try:
+            access_token_json = jwt.decode(access_token, public_key, algorithms='RS256', audience='account')
+        except:
+            print('Failed to authenticate.')
+            return None
+        
+        username = access_token_json['preferred_username']
+        user = User.objects.get(username=username)
+
+        return (user, None)

--- a/components/studio/studio/KCRFbackend.py
+++ b/components/studio/studio/KCRFbackend.py
@@ -2,14 +2,23 @@ from django.contrib.auth.models import User
 from rest_framework import authentication
 from rest_framework import exceptions
 from django.conf import settings
-import modules.keycloak_lib as keylib
 import jwt
+import requests as r
+import modules.keycloak_lib as keylib
+
 
 class KeycloakAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         token_str = request.META['HTTP_AUTHORIZATION']
         access_token = token_str.replace('Token ', '')
-        public_key = b'-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhJMHP2WFMfUGJ1NYRU2JOdorNC96iIdWljLK4v0CjnVi3jRnIBQsnPMB6n1e7Iju2jB0R5gZkWFfhVxnlnJAMyYVZG1/VB/uNL84hywCedFXe3sPj+DUfhZpGirOjGnbtxhdY9qxsYo97H++APNv78RMf3bD04MeRZksxkcJ0SKDJYuXuvPuLdVjwLTSuhY4VJiQcMRrB9DY5ZoQhJMK4fedXOlks1u1IO/w/ArMRl5NLNe18vX4y5r0aGb+PpeCH14YdOvD08NJ3USA7ZOiOKj70xb+SA+lOPBfqU3ijfQe3SbBF9mhdkwSISJIcoNYb8rjNH80ZkoMenh+rRE+wwIDAQAB\n-----END PUBLIC KEY-----'
+        discovery_url = settings.OIDC_OP_REALM_AUTH+'/'+settings.KC_REALM
+        res = r.get(discovery_url)
+        if res:
+            realm_info = res.json()
+            public_key = '-----BEGIN PUBLIC KEY-----\n'+realm_info['public_key']+'\n-----END PUBLIC KEY-----'
+        else:
+            print('Failed to discover realm settings: '+settings.KC_REALM)
+            return None
         try:
             access_token_json = jwt.decode(access_token, public_key, algorithms='RS256', audience='account')
         except:


### PR DESCRIPTION
STACKN-103

CLI has functionality at the user level, by which I mean that you can:

stackn setup (setup config for deployment of STACKn)
stackn login (login user)
stackn get projects (list the user's projects)
stackn set project (set the active project)
stackn set remote (set the active STACKn deployment)
stackn status (show active remote and active project)

This commit means that we don't need to manually generate and download the project.yaml anymore to manage projects.