### PR TITLE
Grant access to a Project without using the Django Admin.

### DIFF
--- a/components/studio/projects/forms.py
+++ b/components/studio/projects/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth.models import User
 
 
 class TransferProjectOwnershipForm(forms.Form):
@@ -8,3 +9,13 @@ class TransferProjectOwnershipForm(forms.Form):
 class PublishProjectToGitHub(forms.Form):
     user_name = forms.CharField(label='GitHub username', max_length=256)
     user_password = forms.CharField(label='GitHub password', widget=forms.PasswordInput(), max_length=256)
+
+
+class GrantAccessForm(forms.Form):
+    platform_users = User.objects.all()
+
+    OPTIONS = []
+    for user in platform_users:
+        OPTIONS.append((user.pk, user.username))
+
+    selected_users = forms.MultipleChoiceField(widget=forms.SelectMultiple, choices=OPTIONS)

--- a/components/studio/projects/templates/settings.html
+++ b/components/studio/projects/templates/settings.html
@@ -149,6 +149,27 @@
         </form>
     </div>
 
+    <div class="container-fluid" style="padding: 15px;">
+        <h5>Grant access</h5>
+        <p>For granting access to this project, select one or more users from the list below.</p>
+        <p>Hold <b>ctrl</b> or <b>shift</b> (or drag with the mouse) to select more than one.</p>
+        <form method="POST" action="{% url 'projects:grant_access' request.user project.slug %}">
+            {% csrf_token %}
+
+            <div class="form-group">
+                <select name="selected_users" required="" multiple="" class="form-control" id="id_selected_users">
+                    {% for user in platform_users %}
+                    <option value="{{ user.pk }}"
+                            {% if user in project.authorized.all %} style="background-color: #D5F5E3;" {% endif %}>
+                        {{ user.username }}
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+    </div>
+
     <div class="container-fluid" style="padding:15px;">
       <h5>Project Settings</h5>
       <h6 style="padding-bottom: 15px;">

--- a/components/studio/projects/urls.py
+++ b/components/studio/projects/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('<user>/<project_slug>/env/change', views.change_environment, name='change_environment'),
     path('<user>/<project_slug>/details/change', views.change_description, name='change_description'),
     path('<user>/<project_slug>/project/publish', views.publish_project, name='publish_project'),
+    path('<user>/<project_slug>/project/access/grant', views.grant_access_to_project, name='grant_access'),
 ]

--- a/components/studio/projects/views.py
+++ b/components/studio/projects/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.conf import settings as sett
 import logging
 import markdown
-from .forms import TransferProjectOwnershipForm, PublishProjectToGitHub
+from .forms import TransferProjectOwnershipForm, PublishProjectToGitHub, GrantAccessForm
 from django.db.models import Q
 from models.models import Model
 import requests as r
@@ -98,6 +98,21 @@ def change_description(request, user, project_slug):
 
     return HttpResponseRedirect(
         reverse('projects:settings', kwargs={'user': request.user, 'project_slug': project.slug}))
+
+
+@login_required(login_url='/accounts/login')
+def grant_access_to_project(request, user, project_slug):
+    project = Project.objects.filter(slug=project_slug).first()
+
+    if request.method == 'POST':
+        form = GrantAccessForm(request.POST)
+        if form.is_valid():
+            selected_users = form.cleaned_data.get('selected_users')
+            project.authorized.set(selected_users)
+            project.save()
+
+    return HttpResponseRedirect(
+        reverse('projects:settings', kwargs={'user': user, 'project_slug': project.slug}))
 
 
 @login_required(login_url='/accounts/login')


### PR DESCRIPTION
With the integration of Keycloak, users don't have access to the Django Admin page which requires an addition to the project's settings page for granting access to other users.

More info -> [JIRA](https://scaleoutsystems.atlassian.net/browse/STACKN-110)