### PR TITLE
Ownership for Lab Sessions.

### DIFF
--- a/components/studio/labs/models.py
+++ b/components/studio/labs/models.py
@@ -54,6 +54,7 @@ class Session(models.Model):
         (ABORTED, 'Aborted'),
     ]
     project = models.ForeignKey('projects.Project', on_delete=models.CASCADE, related_name='session')
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owner')
 
     session_key = models.CharField(max_length=512)
     session_secret = models.CharField(max_length=512)

--- a/components/studio/labs/models.py
+++ b/components/studio/labs/models.py
@@ -15,7 +15,7 @@ class SessionManager(models.Manager):
         password = ''.join(secrets.choice(alphabet) for i in range(length))
         return password
 
-    def create_session(self, name, project, chart, settings, helm_repo=None):
+    def create_session(self, name, project, lab_session_owner, chart, settings, helm_repo=None):
         slug = slugify(name)
         key = self.generate_passkey()
         secret = self.generate_passkey(40)
@@ -23,6 +23,7 @@ class SessionManager(models.Manager):
         status = 'CR'
         session = self.create(name=name,
                               project=project,
+                              lab_session_owner=lab_session_owner,
                               status=status,
                               slug=slug,
                               session_key=key,
@@ -54,7 +55,7 @@ class Session(models.Model):
         (ABORTED, 'Aborted'),
     ]
     project = models.ForeignKey('projects.Project', on_delete=models.CASCADE, related_name='session')
-    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owner')
+    lab_session_owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='lab_session_owner')
 
     session_key = models.CharField(max_length=512)
     session_secret = models.CharField(max_length=512)

--- a/components/studio/labs/views.py
+++ b/components/studio/labs/views.py
@@ -13,7 +13,7 @@ from projects.helpers import get_minio_keys
 def index(request, user, project):
     template = 'labs/index.html'
     project = Project.objects.filter(Q(slug=project), Q(owner=request.user) | Q(authorized=request.user)).first()
-    sessions = Session.objects.filter(project=project)
+    sessions = Session.objects.filter(Q(project=project), Q(owner=request.user))
     flavors = Flavor.objects.all()
     environments = Environment.objects.all()
     url = settings.DOMAIN
@@ -88,9 +88,8 @@ def run(request, user, project):
 
 @login_required(login_url='/accounts/login')
 def delete(request, user, project, id):
-    template = 'labs/index.html'
-    project = Project.objects.filter(Q(slug=project), Q(owner=request.user) | Q(authorized=request.user)).first()
-    session = Session.objects.filter(id=id, project=project).first()
+    project = Project.objects.filter(Q(slug=project), Q(owner=user) | Q(authorized=user)).first()
+    session = Session.objects.filter(Q(id=id), Q(project=project), Q(owner=user)).first()
 
     if session:
         from .helpers import delete_session_resources

--- a/components/studio/labs/views.py
+++ b/components/studio/labs/views.py
@@ -13,7 +13,7 @@ from projects.helpers import get_minio_keys
 def index(request, user, project):
     template = 'labs/index.html'
     project = Project.objects.filter(Q(slug=project), Q(owner=request.user) | Q(authorized=request.user)).first()
-    sessions = Session.objects.filter(Q(project=project), Q(owner=request.user))
+    sessions = Session.objects.filter(Q(project=project), Q(lab_session_owner=request.user))
     flavors = Flavor.objects.all()
     environments = Environment.objects.all()
     url = settings.DOMAIN
@@ -70,7 +70,8 @@ def run(request, user, project):
                      'minio.access_key': decrypted_key,
                      'minio.secret_key': decrypted_secret,
                      }
-            session = Session.objects.create_session(name=name, project=project, chart='lab', settings=prefs)
+            session = Session.objects.create_session(name=name, project=project, lab_session_owner=request.user,
+                                                     chart='lab', settings=prefs)
             from .helpers import create_session_resources
 
             print("trying to create resources")
@@ -88,8 +89,8 @@ def run(request, user, project):
 
 @login_required(login_url='/accounts/login')
 def delete(request, user, project, id):
-    project = Project.objects.filter(Q(slug=project), Q(owner=user) | Q(authorized=user)).first()
-    session = Session.objects.filter(Q(id=id), Q(project=project), Q(owner=user)).first()
+    project = Project.objects.filter(Q(slug=project), Q(owner=request.user) | Q(authorized=request.user)).first()
+    session = Session.objects.filter(Q(id=id), Q(project=project), Q(lab_session_owner=request.user)).first()
 
     if session:
         from .helpers import delete_session_resources

--- a/components/studio/projects/templates/settings.html
+++ b/components/studio/projects/templates/settings.html
@@ -149,6 +149,7 @@
         </form>
     </div>
 
+    {% if project.owner == request.user %}
     <div class="container-fluid" style="padding: 15px;">
         <h5>Grant access</h5>
         <p>For granting access to this project, select one or more users from the list below.</p>
@@ -169,6 +170,7 @@
             <button type="submit" class="btn btn-primary">Save</button>
         </form>
     </div>
+    {% endif %}
 
     <div class="container-fluid" style="padding:15px;">
       <h5>Project Settings</h5>


### PR DESCRIPTION
Added a new field for ownership to the Lab Session class.
Listing Lab Sessions depending on the owner and not on the project.
Removal of Lab Sessions is not possible unless an owner even when the project is shared between users.

Restricted 'Grant access to project' so that only the owner of the project can share it.

More info -> [STACKN-13](https://scaleoutsystems.atlassian.net/browse/STACKN-13) ,  [STACKN-28](https://scaleoutsystems.atlassian.net/browse/STACKN-28)