### PR TITLE
Bug/create project freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ media/generators/
 media/visualisers/
 
 tele_settings.py
+tele_settings_worker.py

--- a/components/studio/experiments/experimentsauth.py
+++ b/components/studio/experiments/experimentsauth.py
@@ -9,7 +9,7 @@ def get_permissions(request, project):
       'delete': ['admin']
     }
 
-    user_roles = set(keylib.keycloak_get_user_roles(request, project,aud=project))
+    user_roles = set(keylib.keycloak_get_user_roles(request, project, aud=project))
     
     user_permissions = dict()
     for rule in rules:

--- a/components/studio/projects/helpers.py
+++ b/components/studio/projects/helpers.py
@@ -1,15 +1,14 @@
-import base64
-
 from .exceptions import ProjectCreationException
 from django.conf import settings
+
+import base64
 import requests as r
 import yaml
-
-from .tasks import create_keycloak_client_task
-
 import re
+import time
 
 import modules.keycloak_lib as keylib
+from .tasks import create_keycloak_client_task, create_helm_resources_task
 
 def urlify(s):
 
@@ -21,52 +20,14 @@ def urlify(s):
 
     return s
 
-def create_settings_file(project, username, token):
-    proj_settings = dict()
-       
-    proj_settings['active'] = 'stackn'
-    proj_settings['client_id'] = 'studio-api'
-    proj_settings['realm'] = settings.KC_REALM
-    proj_settings['active_project'] = 'project'
-
-    return yaml.dump(proj_settings)
-
-
-
-
-def create_project_resources(project, username, repository=None):
-
-    # Create Keycloak client for project with default project role.
-    # The creator of the project assumes all roles by default.
-    create_keycloak_client_task.delay(project.slug, username.username, [])
-
-    create_helm_resources(project, username, repository)
-
     
-
-def create_helm_resources(project, user, repository=None):
-    from rest_framework.authtoken.models import Token
-    token = Token.objects.get_or_create(user=user)
-    proj_settings = create_settings_file(project, user.username, token[0].key)
-    parameters = {'release': str(project.slug),
-                  'chart': 'project',
-                  'minio.access_key': decrypt_key(project.project_key),
-                  'minio.secret_key': decrypt_key(project.project_secret),
-                  'global.domain': settings.DOMAIN,
-                  'storageClassName': settings.STORAGECLASS,
-                  'settings_file': proj_settings}
-    if repository:
-        parameters.update({'labs.repository': repository})
-
-    url = settings.CHART_CONTROLLER_URL + '/deploy'
-
-    retval = r.get(url, parameters)
-    print("CREATE_PROJECT:helm chart creator returned {}".format(retval))
-
-    if retval.status_code >= 200 or retval.status_code < 205:
-        return True
-
-    raise ProjectCreationException(__name__)
+def create_project_resources(project, username, repository=None):
+    res1 = create_keycloak_client_task.delay(project.slug, username, [])
+    res2 = create_helm_resources_task.delay(project.slug, project.project_key, project.project_secret, repository)
+    # Wait for keycloak task to finish before returning (otherwise user wouldn't have
+    # correct Keycloak roles)
+    while not res1.ready():
+        time.sleep(0.1)
 
 
 def delete_project_resources(project):

--- a/components/studio/projects/tasks.py
+++ b/components/studio/projects/tasks.py
@@ -4,7 +4,7 @@ import yaml
 import base64
 
 import modules.keycloak_lib as keylib
-# from .helpers import decrypt_key
+
 from .exceptions import ProjectCreationException
 
 from django.conf import settings
@@ -36,14 +36,9 @@ def create_settings_file(project_slug):
 
     return yaml.dump(proj_settings)
 
-def decrypt_key(key):
-    base64_bytes = key.encode('ascii')
-    result = base64.b64decode(base64_bytes)
-    return result.decode('ascii')
-
 @shared_task
 def create_helm_resources_task(project_slug, project_key, project_secret, repository=None):
-
+    from .helpers import decrypt_key
     proj_settings = create_settings_file(project_slug)
     parameters = {'release': str(project_slug),
                   'chart': 'project',

--- a/components/studio/projects/tasks.py
+++ b/components/studio/projects/tasks.py
@@ -1,12 +1,16 @@
 from celery import shared_task
-# from .helpers import create_environment_image, create_helm_resources
+import requests as r
+import yaml
+import base64
+
 import modules.keycloak_lib as keylib
+# from .helpers import decrypt_key
+from .exceptions import ProjectCreationException
+
 from django.conf import settings
 
 @shared_task
 def create_keycloak_client_task(project_slug, username, repository):
-    # create_environment_image(project, repository)
-    # create_helm_resources(project, username, repository)
     # Create Keycloak client for project with default project role.
     # The creator of the project assumes all roles by default.
     print('Creating Keycloak resources.')
@@ -20,3 +24,45 @@ def create_keycloak_client_task(project_slug, username, repository):
     keylib.keycloak_setup_base_client(URL, RELEASE_NAME, username, settings.PROJECT_ROLES, settings.PROJECT_ROLES)
 
     print('Done Keycloak.')
+
+
+def create_settings_file(project_slug):
+    proj_settings = dict()
+       
+    proj_settings['active'] = 'stackn'
+    proj_settings['client_id'] = 'studio-api'
+    proj_settings['realm'] = settings.KC_REALM
+    proj_settings['active_project'] = project_slug
+
+    return yaml.dump(proj_settings)
+
+def decrypt_key(key):
+    base64_bytes = key.encode('ascii')
+    result = base64.b64decode(base64_bytes)
+    return result.decode('ascii')
+
+@shared_task
+def create_helm_resources_task(project_slug, project_key, project_secret, repository=None):
+
+    proj_settings = create_settings_file(project_slug)
+    parameters = {'release': str(project_slug),
+                  'chart': 'project',
+                  'minio.access_key': decrypt_key(project_key),
+                  'minio.secret_key': decrypt_key(project_secret),
+                  'global.domain': settings.DOMAIN,
+                  'storageClassName': settings.STORAGECLASS,
+                  'settings_file': proj_settings}
+    if repository:
+        parameters.update({'labs.repository': repository})
+
+    url = settings.CHART_CONTROLLER_URL + '/deploy'
+
+    retval = r.get(url, parameters)
+    print("CREATE_PROJECT:helm chart creator returned {}".format(retval))
+
+    if retval.status_code >= 200 or retval.status_code < 205:
+        # return True
+        print('DONE CREATING PROJECT HELM DEPLOYMENT')
+    else:
+        print('FAILED TO CREATE PROJECT HELM DEPLOYMENT')
+        raise ProjectCreationException(__name__)

--- a/components/studio/projects/urls.py
+++ b/components/studio/projects/urls.py
@@ -8,7 +8,6 @@ urlpatterns = [
     path('projects/create', views.create, name='create'),
     path('<user>/<project_slug>', views.details, name='details'),
     path('<user>/<project_slug>/settings', views.settings, name='settings'),
-    path('<user>/<project_slug>/settings/download', views.download_settings, name='download_settings'),
     path('<user>/<project_slug>/delete', views.delete, name='delete'),
     path('<user>/<project_slug>/details/change', views.change_description, name='change_description'),
     path('<user>/<project_slug>/project/publish', views.publish_project, name='publish_project'),

--- a/components/studio/projects/views.py
+++ b/components/studio/projects/views.py
@@ -69,19 +69,6 @@ def settings(request, user, project_slug):
     return render(request, template, locals())
 
 @login_required(login_url='/accounts/login')
-def download_settings(request, user, project_slug):
-    # Get user token
-    from rest_framework.authtoken.models import Token
-    token = Token.objects.get_or_create(user=request.user)
-    project_instance = Project.objects.get(slug=project_slug)
-    proj_settings = "Dummy"
-    # proj_settings = create_settings_file(project_instance, user, token[0].key)
-    response = HttpResponse(proj_settings, content_type='text/plain')
-    response['Content-Disposition'] = 'attachment; filename={0}'.format('project.yaml')
-    return response
-
-
-@login_required(login_url='/accounts/login')
 def change_description(request, user, project_slug):
     project = Project.objects.filter(slug=project_slug).first()
 

--- a/components/studio/scripts/run_worker.sh
+++ b/components/studio/scripts/run_worker.sh
@@ -7,6 +7,13 @@ for d in */ ; do
 done
 cd ..
 
-sleep 30
+[ ! -z "${TELEPRESENCE_ROOT}" ] &&  echo "Copy settings from Telepresence root directory" && \
+    cp $TELEPRESENCE_ROOT/app/studio/settings.py studio/tele_settings_worker.py && \
+    export DJANGO_SETTINGS_MODULE=studio.tele_settings_worker
+# If we have set a local, custom settings.py, then use that.
+[ -f studio/local_settings.py ] && echo "Using local settings file" && export DJANGO_SETTINGS_MODULE=studio.local_settings
+
+
+sleep 1
 
 celery -A studio worker -l info


### PR DESCRIPTION
When creating project, submit both Keycloak role setup and helm resource installation as celery tasks. This was slow before.

Also fixed so that we wait for the roles to actually be created before returning user (or user might not have access to the project until the token is renewed).

Deleted some code related to old project.yaml settings file.