### PR TITLE
List only related project activity.

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.4.0 (upcoming release)
+
+### New functionality
+
+### Bug fixes
+
+- Project's detailed page is now listing only the related activity logs
+
+### Other
+
 ## v0.3.0
 
 ### New functionality


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description

Fixes an issue where all the activity logs are listed instead of only the ones related to the current project.
[Go to JIRA](https://scaleoutsystems.atlassian.net/browse/STACKN-153)

## Types of changes

What types of changes does your code introduce to STACKn?

- [ ] Hotfix (fixing a critical bug in production)
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [x] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/stackn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [x] I have updated the release notes (docs/releasenotes.md)
- [x] I have added a reviewer for this pull request
- [x] I have added myself as an author for this pull request

