### PR TITLE
Feature/SK-121 object permission on transfer project owner

### DIFF
--- a/components/studio/projects/templates/projects/settings.html
+++ b/components/studio/projects/templates/projects/settings.html
@@ -392,7 +392,7 @@
                     <div class="card-body">
                         <h5 class="card-title">Transfer project ownership</h5>
 
-                        <form method="post">
+                        <form action="{% url 'projects:transfer_owner' request.user project.slug %}" method="post">
                             {% csrf_token %}
 
                             <div class="mb-3">

--- a/components/studio/projects/tests.py
+++ b/components/studio/projects/tests.py
@@ -226,6 +226,26 @@ class ProjectViewTestCase(TestCase):
         self.assertTemplateUsed(response, '403.html')
         self.assertEqual(response.status_code, 403)
     
+    def test_transfer_project_owner(self):
+        owner = User.objects.get(username='foo')
+        new_owner = User.objects.get(username='member')
+        project = Project.objects.get(name='test-perm')
+        response = self.client.post(
+            reverse(
+                'projects:transfer_owner', 
+                kwargs={
+                    'user':owner, 
+                    'project_slug':project.slug
+                }
+            ),
+            {
+            'transfer_to': [new_owner.pk]
+            }
+        )
+        project = Project.objects.get(name='test-perm')
+        self.assertEqual(project.owner, new_owner)
+        self.assertTrue(new_owner.has_perm('can_view_project', project))
+        self.assertTrue(owner in project.authorized.all())
     
 
 

--- a/components/studio/projects/urls.py
+++ b/components/studio/projects/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('<user>/<project_slug>', views.details, name='details'),
     path('<user>/<project_slug>/environments/create', views.create_environment, name='create_environment'),
     path('<user>/<project_slug>/settings', views.settings, name='settings'),
+    path('<user>/<project_slug>/transfer', views.transfer_owner, name='transfer_owner'),
     path('<user>/<project_slug>/delete', views.delete, name='delete'),
     path('<user>/<project_slug>/setS3storage', views.set_s3storage, name='set_s3storage'),
     path('<user>/<project_slug>/setmlflow', views.set_mlflow, name='set_mlflow'),


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
Updated transfer project owner view and moved it to  'projects:transfer_owner'. Owner of project can be transferred, but the owner still maintains the 'can_view_project' permission and is added to Project.authorized. I.e the owner becomes a member. 

## Types of changes

What types of changes does your code introduce to STACKn?

- [ ] Hotfix (fixing a critical bug in production)
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update

## Checklist

- [x ] This pull request is against **develop** branch (not applicable for hotfixes)
