### PR TITLE
Feature/SK-148: inactive user option

### DIFF
--- a/components/studio/studio/settings.py
+++ b/components/studio/studio/settings.py
@@ -223,6 +223,8 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = 'login'
 LOGOUT_URL = 'logout'
+#If True, users will be inactive by default on account creation
+INACTIVE_USERS = False
 
 # Specific to Studio stack:
 # Redis settings

--- a/components/studio/studio/views.py
+++ b/components/studio/studio/views.py
@@ -2,6 +2,19 @@ from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from projects.models import Project
 
+from django.dispatch import receiver
+from django.db.models.signals import pre_save
+from django.contrib.auth.models import User
+from django.conf import settings
+
+@receiver(pre_save, sender=User)
+def set_new_user_inactive(sender, instance, **kwargs):
+    if instance._state.adding is True and settings.INACTIVE_USERS:
+        print("Creating Inactive User")
+        instance.is_active = False
+    else:
+        print("Updating User Record")
+
 # Since this is a production feature, it will only work if DEBUG is set to False
 def handle_page_not_found(request, exception):
     return HttpResponseRedirect('/')


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description

For security one can now enable users to be inactive by default upon account creation. Admin has to modify user instance to be active after account creation if INACTIVE_USERS = True (default False). 
