### PR TITLE
Feature/SK-145 Serve Apps and ingress auth

### DIFF
--- a/components/studio/apps/fixtures/apps_fixtures.json
+++ b/components/studio/apps/fixtures/apps_fixtures.json
@@ -668,6 +668,9 @@
       "description": "",
       "priority": "500",
       "settings": {
+        "model": {
+          "object_type": "pytorch"
+        },
         "logs": [
           "serve"
         ],

--- a/components/studio/apps/views.py
+++ b/components/studio/apps/views.py
@@ -252,12 +252,15 @@ def create(request, user, project, app_slug, data=[], wait=False, call=False):
         permission.projects.set([])
         permission.users.set([])
         
+        access = ""
 
         if parameters_out['permissions']['public']:
             permission.public = True
+            access = "public"
         elif parameters_out['permissions']['project']:
             print("PROJECT PERMISSIONS")
             client_id = project.slug
+            access = "project"
 
             if not 'project' in parameters_out:
                 parameters_out['project'] = dict()
@@ -268,10 +271,11 @@ def create(request, user, project, app_slug, data=[], wait=False, call=False):
             parameters_out['project']['name'] = project.name
             permission.projects.set([project])
         elif parameters_out['permissions']['private']:
+            access = "private"
             permission.users.set([user])
         permission.save()
 
-        app_instance = AppInstance(name=app_name, app=app, project=project, info={},
+        app_instance = AppInstance(name=app_name, access=access, app=app, project=project, info={},
                                     parameters=parameters_out,owner=user)
 
         if data.get('app_action') == "Create":

--- a/components/studio/charts/apps/dash-app/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/dash-app/chart/templates/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}
@@ -27,6 +29,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
 spec:
   rules:
     - host: {{ .Release.Name }}.{{ .Values.global.domain }}

--- a/components/studio/charts/apps/docker-registry/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/docker-registry/chart/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -30,7 +30,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/fastapi-serve/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/fastapi-serve/chart/templates/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-fastapi-ingress
   namespace: {{ .Values.namespace }}
 spec:
@@ -29,6 +31,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
 spec:

--- a/components/studio/charts/apps/jupyter-lab/chart/templates/project-labs-ingress.yaml
+++ b/components/studio/charts/apps/jupyter-lab/chart/templates/project-labs-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -35,7 +35,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/minio/chart/templates/project-s3-ingress.yaml
+++ b/components/studio/charts/apps/minio/chart/templates/project-s3-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "20000m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
   name: {{ .Release.Name }}-minio
@@ -28,7 +28,7 @@ kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "20000m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
   name: {{ .Release.Name }}-minio

--- a/components/studio/charts/apps/mlflow-serve/chart/templates/deployment.yaml
+++ b/components/studio/charts/apps/mlflow-serve/chart/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
   selector:
     matchLabels:
       release: {{ .Release.Name }}
-      app: fastapi-serve
+      app: mlflow-serve
       project: {{ .Values.project.slug }}
       type: app
-      pod: fastapi-serve
+      pod: mlflow-serve
   template:
     metadata:
       annotations:
@@ -24,10 +24,10 @@ spec:
         prometheus.io/port: "8501"
       labels:
         release: {{ .Release.Name }}
-        app: fastapi-serve
+        app: mlflow-serve
         project: {{ .Values.project.slug }}
         type: app
-        pod: fastapi-serve
+        pod: mlflow-serve
     spec:
       volumes:
       - name: rp-conf
@@ -40,9 +40,6 @@ spec:
       {{ end }}
       - name: model-vol
         emptyDir: {}
-      {{- with .Values.extraVolumes }}
-      {{- tpl . $ | nindent 6 }}
-      {{- end }}
       {{ if .Values.environment.registry }}
       imagePullSecrets:
         - name: {{ .Release.Name }}-pull-secret
@@ -119,6 +116,8 @@ spec:
             memory: 128Mi
       {{ end }}
       - name: serve
+        command: ["/bin/sh"]
+        args: ["-c", "mlflow models serve -m models/model -h 0.0.0.0"]
         resources:
           limits:
             cpu: {{ .Values.flavor.limits.cpu }}
@@ -132,13 +131,13 @@ spec:
         {{- with .Values.extraVolumeMounts }}
         {{- tpl . $ | nindent 8 }}
         {{- end }}
-        env:
-        - name: GUNICORN_CMD_ARGS
-          value: "--limit-request-field_size 0"
-          {{- with .Values.extraEnv }}
-          {{- tpl . $ | nindent 10 }}
-          {{- end }}
+        # env:
+        # - name: GUNICORN_CMD_ARGS
+        #   value: "--limit-request-field_size 0"
+        #   {{- with .Values.extraEnv }}
+        #   {{- tpl . $ | nindent 10 }}
+        #   {{- end }}
         image: {{ .Values.environment.repository }}/{{ .Values.environment.image }}
         imagePullPolicy: Always
         ports:
-        - containerPort: {{ .Values.default_values.port }}
+        - containerPort: 5000

--- a/components/studio/charts/apps/mlflow-serve/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/mlflow-serve/chart/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     # nginx.ingress.kubernetes.io/rewrite-target: /$1
   name: {{ .Release.Name }}-ingress
@@ -32,7 +32,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     # nginx.ingress.kubernetes.io/rewrite-target: /$1
   name: {{ .Release.Name }}-ingress

--- a/components/studio/charts/apps/mlflow-serve/chart/templates/service.yaml
+++ b/components/studio/charts/apps/mlflow-serve/chart/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 8501
+    targetPort: 5000
   selector:
     release: {{ .Release.Name }}

--- a/components/studio/charts/apps/mlflow/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/mlflow/chart/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -34,7 +34,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/mongo-express/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/mongo-express/chart/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -28,7 +28,7 @@ metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/pytorch-serve/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/pytorch-serve/chart/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
@@ -33,7 +33,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}

--- a/components/studio/charts/apps/rstudio/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/rstudio/chart/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     io.kompose.service: {{ .Release.Name }}-rstudio
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -34,7 +34,7 @@ metadata:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "5500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/tensorflow-serve/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/tensorflow-serve/chart/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
@@ -33,7 +33,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}

--- a/components/studio/charts/apps/vscode/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/vscode/chart/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -32,7 +32,7 @@ metadata:
   labels:
     io.kompose.service: {{ .Release.Name }}-ingress
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/charts/apps/wetty-terminal/chart/templates/ingress.yaml
+++ b/components/studio/charts/apps/wetty-terminal/chart/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Values.namespace }}
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:
@@ -28,7 +28,7 @@ metadata:
   name: {{ .Release.Name }}-wetty
   namespace: {{ .Values.namespace }}
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?project={{ .Values.project.slug }}"
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.global.protocol }}://{{ .Values.global.auth_domain }}:8080/auth/?release={{ .Values.release }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.global.protocol }}://{{ .Values.global.domain }}:8080/accounts/login/?next=$scheme%3A%2F%2F$host"
     #nginx.ingress.kubernetes.io/auth-response-headers: X-Forwarded-Host
 spec:

--- a/components/studio/common/views.py
+++ b/components/studio/common/views.py
@@ -3,6 +3,7 @@ from django.http.response import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, TemplateView
 from .forms import SignUpForm
+from django.conf import settings
 
 # Create your views here.
 class HomeView(TemplateView):
@@ -17,7 +18,11 @@ class SignUpView(CreateView):
         form = self.get_form()
         if form.is_valid():
             form.save()
-            messages.success(request, "Account created successfully!")
+            if settings.INACTIVE_USERS:
+                messages.success(request, "Account request has been registered! Please wait for admin to approve!")    
+            else:
+                messages.success(request, "Account created successfully!")
+
             return HttpResponseRedirect(reverse_lazy('login'))
 
         # Otherwise use built-in parent class-based checks

--- a/components/studio/projects/views.py
+++ b/components/studio/projects/views.py
@@ -452,7 +452,9 @@ def details(request, user, project_slug):
             rslugs.append({"slug": cat.slug, "name": cat.name})
 
         for rslug in rslugs:
-            tmp = AppInstance.objects.filter(~Q(state="Deleted"), project=project, app__category__slug=rslug['slug']).order_by('-created_on')[:5]
+            tmp = AppInstance.objects.filter(~Q(state="Deleted"),Q(owner=request.user) | Q(permission__projects__slug=project.slug) |  Q(permission__public=True), 
+                                            project=project, 
+                                            app__category__slug=rslug['slug']).order_by('-created_on')[:5]
             for instance in tmp:
                 pk_list += str(instance.pk)+','
             apps_filtered = Apps.objects.filter(category__slug=rslug['slug']).order_by('slug', '-revision').distinct('slug')

--- a/components/studio/studio/urls.py
+++ b/components/studio/studio/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('', include('models.urls', namespace='models')),
     path('', include('portal.urls', namespace='portal')),
     path('', include('projects.urls', namespace='projects')),
-    path('auth/', views.auth),
+    path('auth/', views.AuthView.as_view()),
     path('accounts/', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
     path('api/', include('api.urls', namespace='api')),

--- a/components/studio/studio/views.py
+++ b/components/studio/studio/views.py
@@ -1,11 +1,15 @@
 from django.http import HttpResponseRedirect
-from django.http import HttpResponse
 from projects.models import Project
 
 from django.dispatch import receiver
 from django.db.models.signals import pre_save
 from django.contrib.auth.models import User
 from django.conf import settings
+
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 @receiver(pre_save, sender=User)
 def set_new_user_inactive(sender, instance, **kwargs):
@@ -19,12 +23,24 @@ def set_new_user_inactive(sender, instance, **kwargs):
 def handle_page_not_found(request, exception):
     return HttpResponseRedirect('/')
 
-def auth(request):
-    if request.user.is_authenticated:
+from rest_framework.permissions import BasePermission
+
+class ProjectPermission(BasePermission):
+
+    def has_permission(self, request, view):
+        """
+        Should simply return, or raise a 403 response.
+        """
         project_slug = request.GET.get('project')
         project = Project.objects.get(slug=project_slug)
-        if request.user.has_perm('can_view_project', project):
-            return HttpResponse(status=200)
-        else:
-            return HttpResponse(status=403)
-    return HttpResponse(status=401)
+        return request.user.has_perm('can_view_project', project)
+class AuthView(APIView):
+    authentication_classes = [SessionAuthentication, TokenAuthentication]
+    permission_classes = [IsAuthenticated, ProjectPermission]
+
+    def get(self, request, format=None):
+        content = {
+            'user': str(request.user),
+            'auth': str(request.auth),
+        }
+        return Response(content)


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
Some changes done for serving apps. Auth endpoint is now APIView to enable both session and token based authentication. Serve apps are guarded by this auth endpoint, thus requests need Authorization header. 

Updated access field of app instance. Auth endpoint permission is based on this field (private, public or project).

Dashboard filter of apps updated based on access/permissions.

updated message for when INACTIVE_USERS = True in settings.
