### PR TITLE
Fix/SK-157 REST SessionAuth won't return status code 401

### DIFF
--- a/components/studio/studio/views.py
+++ b/components/studio/studio/views.py
@@ -46,8 +46,21 @@ class AccessPermission(BasePermission):
             return request.user.has_perm('can_view_project', project)
         else:
             return True
+class ModifiedSessionAuthentication(SessionAuthentication):
+    """
+    This class is needed, because REST Framework's default SessionAuthentication does never return 401's,
+    because they cannot fill the WWW-Authenticate header with a valid value in the 401 response. As a
+    result, we cannot distinguish calls that are not unauthorized (401 unauthorized) and calls for which
+    the user does not have permission (403 forbidden). See https://github.com/encode/django-rest-framework/issues/5968
+
+    We do set authenticate_header function in SessionAuthentication, so that a value for the WWW-Authenticate
+    header can be retrieved and the response code is automatically set to 401 in case of unauthenticated requests.
+    """
+    def authenticate_header(self, request):
+        return 'Session'
+
 class AuthView(APIView):
-    authentication_classes = [SessionAuthentication, TokenAuthentication]
+    authentication_classes = [ModifiedSessionAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated, AccessPermission]
 
     def get(self, request, format=None):


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
The SessionAuthentication in django rest framework will not return 401 if user is not authenticated instead it returns 403 Forbidden. This is a fix for that.   

