### PR TITLE
Fix/SK-132 App settings and post delete hooks for mlflow and S3

### DIFF
--- a/components/studio/apps/tasks.py
+++ b/components/studio/apps/tasks.py
@@ -127,10 +127,17 @@ def post_delete_hooks(instance):
     # Free up release name (if reserved)
     print("TASK - POST DELETE HOOK...")
     rel_names = instance.releasename_set.all()
+    project = instance.project
     for rel_name in rel_names:
         rel_name.status = 'active'
         rel_name.app = None
         rel_name.save()
+    if project.s3storage.app == instance:
+        project.s3storage.delete()
+    elif project.mlflow.app == instance:
+        project.mlflow.delete()
+        
+
 
 @shared_task
 @transaction.atomic

--- a/components/studio/apps/views.py
+++ b/components/studio/apps/views.py
@@ -242,8 +242,8 @@ def create(request, user, project, app_slug, data=[], wait=False, call=False):
             permission = AppPermission(name=app_name)
             permission.save()
         elif data.get('app_action') == "Settings":
-            instance = AppInstance.objects.get(pk=data.get('app_id'))
-            permission = instance.permission
+            app_instance = AppInstance.objects.get(pk=data.get('app_id'))
+            permission = app_instance.permission
         else:
             print("No action set, aborting...")
             print(data.get('app_action'))
@@ -275,11 +275,10 @@ def create(request, user, project, app_slug, data=[], wait=False, call=False):
             permission.users.set([user])
         permission.save()
 
-        app_instance = AppInstance(name=app_name, access=access, app=app, project=project, info={},
-                                    parameters=parameters_out,owner=user)
-
         if data.get('app_action') == "Create":
-
+            app_instance = AppInstance(name=app_name, access=access, app=app, project=project, info={},
+                                    parameters=parameters_out,owner=user)
+            
             create_instance_params(app_instance, "create")
             
             # Attempt to create a ReleaseName model object

--- a/components/studio/templates/base.html
+++ b/components/studio/templates/base.html
@@ -214,6 +214,7 @@
             var self = $(this)
             swal({
                 title: "Do You Really Want to Delete This?",
+                text: "Observe that this app might be a dependecy in other app instances!",
                 icon: "warning",
                 buttons: true,
                 dangerMode: true,
@@ -223,6 +224,7 @@
                     swal({
                     title: "Done!",
                     icon: "success",
+                    buttons: false
                     });
                     setTimeout(() => { console.log("Showing result for 1 sec..."); location.href = self.attr('href')}, 800);
                 }


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
Updating app settings was not working, fixed by app instance variable. When deleting minio or mlflow, apps they still remain coupled to project.mlflow and project.s3storage. Added post delete hooks for deleting these.

Additional: updated sweetalert message when deleting apps. 